### PR TITLE
refactor(db): drop bill_totals/purchase_bill_totals views

### DIFF
--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -5,13 +5,13 @@
 -- name: GetAllBill :many
 SELECT * from(
 			SELECT bill.id as id, effective_date, payment_due_date, bill.state as state, discount, sequence_number, bill.user_phone_number, client.id is not null as bill_type, cn.state as credit_state, total, total_vat, total_before_vat
-			FROM bill_totals as bill
+			FROM bill
 			JOIN credit_note  cn on cn.bill_id = bill.id
 			LEFT JOIN client  on client.id = bill.client_id
 			WHERE bill.state >= 0
 			and (sqlc.narg('phonenumber') is null or bill.user_phone_number like sqlc.narg('phonenumber'))
 			UNION
-			SELECT bill.id as id, effective_date, payment_due_date, bill.state as state, discount, sequence_number, user_phone_number, client.id is not null as bill_type, 0 as credit_state, total, total_vat, total_before_vat from bill_totals as bill
+			SELECT bill.id as id, effective_date, payment_due_date, bill.state as state, discount, sequence_number, user_phone_number, client.id is not null as bill_type, 0 as credit_state, total, total_vat, total_before_vat from bill
 			LEFT JOIN client  on client.id = bill.client_id
 			WHERE bill. state >= 0
 			and (sqlc.narg('phonenumber') is null or bill.user_phone_number like sqlc.narg('phonenumber'))
@@ -52,7 +52,7 @@ COALESCE(
 	FROM bill_product p
 	WHERE p.bill_id = b.id),
   JSON_ARRAY()) AS products
-FROM bill_totals b
+FROM bill b
 JOIN store on store.id = b.store_id
 JOIN company on company.id = store.company_id
 WHERE b.id = ? LIMIT 1 ;
@@ -68,7 +68,7 @@ store.name as store_name,
 cn.state as credit_state,
 cn.note as credit_note,
 cn.id as credit_id
-FROM bill_totals b
+FROM bill b
 JOIN store on store.id = b.store_id
 JOIN company on company.id = store.company_id
 LEFT JOIN credit_note cn on cn.bill_id = b.id

--- a/pkg/db/queries/purchase_bill.sql
+++ b/pkg/db/queries/purchase_bill.sql
@@ -1,6 +1,6 @@
 -- name: GetAllPurchaseBill :many
 select b.*
-	from purchase_bill_totals as b
+	from purchase_bill as b
 	join store on store.id = b.store_id
 	join company on company.id = store.company_id
 	join user on user.id= ? and company.id=user.company_id
@@ -9,7 +9,7 @@ select b.*
 
 -- name: GetPurchaseBillDetail :one
 select b.*
-	from purchase_bill_totals as b
+	from purchase_bill as b
 	join store on store.id = b.store_id
 	join company on company.id = store.company_id
 	join user on user.id = ? and company.id=user.company_id

--- a/pkg/db/schema/schema.sql
+++ b/pkg/db/schema/schema.sql
@@ -628,37 +628,6 @@ CREATE TABLE `bill_product` (
 /*!50003 SET collation_connection  = @saved_col_connection */ ;
 
 --
--- Temporary view structure for view `bill_totals`
---
-
-DROP TABLE IF EXISTS `bill_totals`;
-/*!50001 DROP VIEW IF EXISTS `bill_totals`*/;
-SET @saved_cs_client     = @@character_set_client;
-/*!50503 SET character_set_client = utf8mb4 */;
-/*!50001 CREATE VIEW `bill_totals` AS SELECT 
- 1 AS `id`,
- 1 AS `effective_date`,
- 1 AS `payment_due_date`,
- 1 AS `state`,
- 1 AS `discount`,
- 1 AS `store_id`,
- 1 AS `sequence_number`,
- 1 AS `merchant_id`,
- 1 AS `maintenance_cost`,
- 1 AS `note`,
- 1 AS `userName`,
- 1 AS `client_id`,
- 1 AS `user_phone_number`,
- 1 AS `payment_method`,
- 1 AS `branch_id`,
- 1 AS `deliver_date`,
- 1 AS `total_before_vat`,
- 1 AS `total_vat`,
- 1 AS `total`,
- 1 AS `qr_code`*/;
-SET character_set_client = @saved_cs_client;
-
---
 -- Table structure for table `bodymark`
 --
 
@@ -1864,30 +1833,6 @@ CREATE TABLE `purchase_bill_product` (
 /*!50003 SET @saved_sql_mode       = @@sql_mode */ ;
 /*!50003 SET sql_mode              = 'ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION' */ ;
 
-DROP TABLE IF EXISTS `purchase_bill_totals`;
-/*!50001 DROP VIEW IF EXISTS `purchase_bill_totals`*/;
-SET @saved_cs_client     = @@character_set_client;
-/*!50503 SET character_set_client = utf8mb4 */;
-/*!50001 CREATE VIEW `purchase_bill_totals` AS SELECT 
- 1 AS `id`,
- 1 AS `effective_date`,
- 1 AS `payment_due_date`,
- 1 AS `state`,
- 1 AS `discount`,
- 1 AS `supplier_id`,
- 1 AS `sequence_number`,
- 1 AS `supplier_sequence_number`,
- 1 AS `vat_sequence_number`,
- 1 AS `store_id`,
- 1 AS `merchant_id`,
- 1 AS `pdf_link`,
- 1 AS `payment_method`,
- 1 AS `deliver_date`,
- 1 AS `total_before_vat`,
- 1 AS `total_vat`,
- 1 AS `total`*/;
-SET character_set_client = @saved_cs_client;
-
 --
 -- Table structure for table `refresh_token`
 --
@@ -2378,24 +2323,6 @@ CREATE TABLE `zatca_submission` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Final view structure for view `bill_totals`
---
-
-/*!50001 DROP VIEW IF EXISTS `bill_totals`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `bill_totals` AS select `b`.`id` AS `id`,`b`.`effective_date` AS `effective_date`,`b`.`payment_due_date` AS `payment_due_date`,`b`.`state` AS `state`,`b`.`discount` AS `discount`,`b`.`store_id` AS `store_id`,`b`.`sequence_number` AS `sequence_number`,`b`.`merchant_id` AS `merchant_id`,`b`.`maintenance_cost` AS `maintenance_cost`,`b`.`note` AS `note`,`b`.`userName` AS `userName`,`b`.`client_id` AS `client_id`,`b`.`user_phone_number` AS `user_phone_number`,`b`.`payment_method` AS `payment_method`,`b`.`branch_id` AS `branch_id`,`b`.`deliver_date` AS `deliver_date`,round(coalesce(sum(`bp`.`total_before_vat`),0),2) AS `total_before_vat`,round(coalesce(sum(`bp`.`vat_total`),0),2) AS `total_vat`,round(coalesce(sum(`bp`.`total_including_vat`),0),2) AS `total`,`b`.`qr_code` AS `qr_code` from (`bill` `b` left join `bill_product` `bp` on((`b`.`id` = `bp`.`bill_id`))) group by `b`.`id` */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
-
---
 -- Final view structure for view `cash_voucher_summary`
 --
 
@@ -2413,23 +2340,6 @@ CREATE TABLE `zatca_submission` (
 /*!50001 SET character_set_results     = @saved_cs_results */;
 /*!50001 SET collation_connection      = @saved_col_connection */;
 
---
--- Final view structure for view `purchase_bill_totals`
---
-
-/*!50001 DROP VIEW IF EXISTS `purchase_bill_totals`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `purchase_bill_totals` AS select `b`.`id` AS `id`,`b`.`effective_date` AS `effective_date`,`b`.`payment_due_date` AS `payment_due_date`,`b`.`state` AS `state`,`b`.`discount` AS `discount`,`b`.`supplier_id` AS `supplier_id`,`b`.`sequence_number` AS `sequence_number`,`b`.`supplier_sequence_number` AS `supplier_sequence_number`,`b`.`vat_sequence_number` AS `vat_sequence_number`,`b`.`store_id` AS `store_id`,`b`.`merchant_id` AS `merchant_id`,`b`.`pdf_link` AS `pdf_link`,`b`.`payment_method` AS `payment_method`,`b`.`deliver_date` AS `deliver_date`,round(coalesce(sum(`bp`.`total_before_vat`),0),2) AS `total_before_vat`,round(coalesce(sum(`bp`.`vat_total`),0),2) AS `total_vat`,round(coalesce(sum(`bp`.`total_including_vat`),0),2) AS `total` from (`purchase_bill` `b` left join `purchase_bill_product` `bp` on((`b`.`id` = `bp`.`bill_id`))) group by `b`.`id` */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;

--- a/pkg/handlers/purchase_bill.go
+++ b/pkg/handlers/purchase_bill.go
@@ -17,7 +17,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func (h *handler) getPurchaseBills(c *gin.Context, page int32, pageSize int32, userID int32) []db.PurchaseBillTotal {
+func (h *handler) getPurchaseBills(c *gin.Context, page int32, pageSize int32, userID int32) []db.PurchaseBill {
 
 	args := db.GetAllPurchaseBillParams{
 		ID:     userID,


### PR DESCRIPTION
## Summary

Stop relying on the `bill_totals` and `purchase_bill_totals` SQL views. Both base tables now carry their own totals (`total_before_vat`, `total_vat`, `total`, plus `amount_paid` for purchase bills, and `discount_amount` for sales bills), so the per-bill aggregate views are redundant.

### What changed
- `pkg/db/queries/bill.sql`
  - `GetAllBill`, `GetBillByID`, `GetBillPDFByID`: `FROM bill_totals … b` → `FROM bill … b`
- `pkg/db/queries/purchase_bill.sql`
  - `GetAllPurchaseBill`, `GetPurchaseBillDetail`: `from purchase_bill_totals as b` → `from purchase_bill as b`
- `pkg/db/schema/schema.sql`
  - Removed both placeholder and final `CREATE VIEW` blocks for `bill_totals` and `purchase_bill_totals`.
- `pkg/handlers/purchase_bill.go`
  - `getPurchaseBills` now returns `[]db.PurchaseBill` (sqlc infers the table model since `select b.*` is over the base table).

### Migration / deploy notes
1. **Drop the views in any existing DB** (idempotent):
   ```sql
   DROP VIEW IF EXISTS bill_totals;
   DROP VIEW IF EXISTS purchase_bill_totals;
   ```
2. **Regenerate sqlc code** before building:
   ```
   sqlc generate
   ```
   (`pkg/db/gen/` is gitignored.)

### Verified locally
- `go build ./...` clean.
- `POST /bill/all` → 200 with rows containing `total/total_vat/total_before_vat`.
- `POST /purchase_bill/all` → 200, now includes `received_at`, `received_by`, `amount_paid` (extra columns the table has but the view didn't).
- `GET /purchase_bill/:id` → 200 detail with products payload.
