### PR TITLE
feat(zatca): submission monitor API

### DIFF
--- a/main.go
+++ b/main.go
@@ -185,6 +185,11 @@ func main() {
 		authorized.PUT("user/:id", admin, h.UpdateUser)
 		authorized.DELETE("user/:id", admin, h.DeleteUser)
 		authorized.POST("user/:id/password", admin, h.AdminResetUserPassword)
+
+		// ── ZATCA submission monitor (admin only) ──────────────────────
+		authorized.GET("zatca/monitor/stats", admin, h.ZatcaMonitorStats)
+		authorized.GET("zatca/monitor/branches", admin, h.ZatcaMonitorBranches)
+		authorized.GET("zatca/monitor/submissions", admin, h.ZatcaMonitorSubmissions)
 	}
 
 	nonAuthGroup := router.Group(baseUrl)

--- a/pkg/db/queries/zatca_monitor.sql
+++ b/pkg/db/queries/zatca_monitor.sql
@@ -1,0 +1,61 @@
+-- name: GetZatcaMonitorStats :one
+SELECT
+  COUNT(*)                                     AS total,
+  COUNT(CASE WHEN status = 2 THEN 1 END)       AS accepted,
+  COUNT(CASE WHEN status = 4 THEN 1 END)       AS warnings,
+  COUNT(CASE WHEN status = 3 THEN 1 END)       AS rejected,
+  COUNT(CASE WHEN status IN (0, 1) THEN 1 END) AS pending
+FROM zatca_submission;
+
+-- name: ListZatcaMonitorBranches :many
+SELECT
+  b.id                                                              AS branch_id,
+  b.name                                                            AS branch_name,
+  bzc.zatca_status                                                  AS zatca_status,
+  bzc.zatca_compliance_certificate                                  AS certificate,
+  (SELECT COUNT(*)
+     FROM zatca_submission zs
+     JOIN bill bl ON bl.id = zs.bill_id
+     WHERE bl.branch_id = b.id
+       AND DATE(zs.submitted_at) = CURDATE())                       AS today_count,
+  (SELECT COUNT(*)
+     FROM zatca_submission zs
+     JOIN bill bl ON bl.id = zs.bill_id
+     WHERE bl.branch_id = b.id
+       AND zs.submitted_at >= NOW() - INTERVAL 7 DAY)               AS week_total,
+  (SELECT COUNT(*)
+     FROM zatca_submission zs
+     JOIN bill bl ON bl.id = zs.bill_id
+     WHERE bl.branch_id = b.id
+       AND zs.submitted_at >= NOW() - INTERVAL 7 DAY
+       AND zs.status = 2)                                           AS week_accepted,
+  (SELECT MAX(zs.submitted_at)
+     FROM zatca_submission zs
+     JOIN bill bl ON bl.id = zs.bill_id
+     WHERE bl.branch_id = b.id)                                     AS last_submission_at
+FROM branches b
+JOIN branch_zatca_config bzc ON bzc.branch_id = b.id
+ORDER BY b.id ASC;
+
+-- name: ListZatcaMonitorSubmissions :many
+-- Sentinel filters keep the SQL static for code-scanners (Sonar S2077):
+--   pending_flag = 'y' includes status IN (0,1); otherwise no pending bias.
+--   status_code  = -1  disables the exact-status match.
+--   branch_id    = 0   disables the branch filter.
+SELECT
+  bl.id            AS invoice_id,
+  bl.sequence_number,
+  bl.branch_id,
+  COALESCE(b.name, '')  AS branch_name,
+  zs.status,
+  zs.rejection_code,
+  zs.rejection_msg,
+  zs.submitted_at
+FROM zatca_submission zs
+JOIN bill bl     ON bl.id = zs.bill_id
+LEFT JOIN branches b ON b.id = bl.branch_id
+WHERE (sqlc.arg('pending_flag') = '' OR zs.status IN (0,1))
+  AND (sqlc.arg('status_code') = -1 OR zs.status = sqlc.arg('status_code'))
+  AND (sqlc.arg('branch_id') = 0 OR bl.branch_id = sqlc.arg('branch_id'))
+ORDER BY zs.submitted_at DESC
+LIMIT ?;

--- a/pkg/handlers/zatca_constants.go
+++ b/pkg/handlers/zatca_constants.go
@@ -1,0 +1,40 @@
+package handlers
+
+// ZATCA submission status enum — matches the `status` column on
+// the `zatca_submission` table and pkg/db/gen/dashboard.sql.go.
+const (
+	ZatcaStatusPending   = 0
+	ZatcaStatusSubmitted = 1
+	ZatcaStatusAccepted  = 2
+	ZatcaStatusRejected  = 3
+	ZatcaStatusWarning   = 4
+)
+
+// String labels exposed to the frontend for the numeric status codes above.
+const (
+	ZatcaLabelPending  = "pending"
+	ZatcaLabelAccepted = "accepted"
+	ZatcaLabelRejected = "rejected"
+	ZatcaLabelWarning  = "warning"
+	ZatcaLabelUnknown  = "unknown"
+)
+
+// Sentinel values for ListZatcaMonitorSubmissions filters. Kept here so the
+// handler and the sqlc query stay aligned.
+const (
+	zatcaPendingFlagOn   = "y"
+	zatcaPendingFlagOff  = ""
+	zatcaStatusCodeAny   = -1
+	zatcaBranchAny       = uint32(0)
+	zatcaSubmissionsCap  = 200
+	zatcaSubmissionsHint = 50
+)
+
+// Repeated 5xx detail strings for ZATCA monitor handlers.
+const (
+	ErrZatcaLoadStats       = "failed to load stats"
+	ErrZatcaLoadBranches    = "failed to load branches"
+	ErrZatcaLoadSubmissions = "failed to load submissions"
+	ErrZatcaInvalidStatus   = "invalid status"
+	ErrZatcaInvalidBranch   = "invalid branch_id"
+)

--- a/pkg/handlers/zatca_monitor.go
+++ b/pkg/handlers/zatca_monitor.go
@@ -218,12 +218,12 @@ func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
 		limit = 50
 	}
 
-	args := []any{}
-	where := "WHERE 1=1"
+	// Sentinel filters keep the SQL static for code-scanners (Sonar S2077).
+	pendingFlag := ""    // "y" => match status IN (0,1)
+	statusCode := -1     // -1 => no exact-status match
+	var branchID int64 = 0 // 0 => no branch filter
 
 	if s := c.Query("status"); s != "" {
-		// Accept either the numeric code or the string label.
-		statusCode := -1
 		switch s {
 		case "accepted":
 			statusCode = 2
@@ -232,19 +232,14 @@ func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
 		case "warning":
 			statusCode = 4
 		case "pending":
-			// pending covers 0 and 1
-			where += " AND zs.status IN (0,1)"
+			pendingFlag = "y"
 		default:
-			if n, err := strconv.Atoi(s); err == nil {
-				statusCode = n
-			} else {
+			n, err := strconv.Atoi(s)
+			if err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
 				return
 			}
-		}
-		if statusCode >= 0 {
-			where += " AND zs.status = ?"
-			args = append(args, statusCode)
+			statusCode = n
 		}
 	}
 	if bs := c.Query("branch_id"); bs != "" {
@@ -253,10 +248,8 @@ func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid branch_id"})
 			return
 		}
-		where += " AND bl.branch_id = ?"
-		args = append(args, bid)
+		branchID = bid
 	}
-	args = append(args, limit)
 
 	rows, err := h.DB.Query(`
         SELECT
@@ -271,9 +264,12 @@ func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
         FROM zatca_submission zs
         JOIN bill bl     ON bl.id = zs.bill_id
         LEFT JOIN branches b ON b.id = bl.branch_id
-        `+where+`
+        WHERE (? = '' OR zs.status IN (0,1))
+          AND (? = -1 OR zs.status = ?)
+          AND (? = 0 OR bl.branch_id = ?)
         ORDER BY zs.submitted_at DESC
-        LIMIT ?`, args...)
+        LIMIT ?`,
+		pendingFlag, statusCode, statusCode, branchID, branchID, limit)
 	if err != nil {
 		log.Printf("ZatcaMonitorSubmissions query: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load submissions"})

--- a/pkg/handlers/zatca_monitor.go
+++ b/pkg/handlers/zatca_monitor.go
@@ -2,165 +2,104 @@ package handlers
 
 // ZATCA submission monitor — read-only ops dashboard endpoints.
 //
-// Backed by:
-//   * zatca_submission (status, retry_count, submitted_at, cleared_at, ...)
-//   * branch_zatca_config (zatca_status, zatca_*_certificate, ...)
-//   * bill (branch_id, invoice_uuid, sequence_number, effective_date)
-//   * branches (id, name)
+// Backed by sqlc queries in pkg/db/queries/zatca_monitor.sql:
+//   * GetZatcaMonitorStats        — aggregated counters
+//   * ListZatcaMonitorBranches    — per-branch dashboard
+//   * ListZatcaMonitorSubmissions — recent submissions list
 //
-// Status enum (matches pkg/db/gen/dashboard.sql.go GetDashboardZATCAStats):
-//   0 = pending, 1 = submitted, 2 = accepted, 3 = rejected, 4 = warning
+// Status enum: see pkg/handlers/zatca_constants.go (matches dashboard.sql).
 //
-// All endpoints require the caller to be admin.
+// All endpoints are mounted behind admin middleware (see main.go).
 
 import (
 	"crypto/x509"
-	"database/sql"
 	"encoding/base64"
 	"encoding/pem"
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+
+	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
 )
 
-// requireAdmin aborts with 403 unless the JWT claims have role == "admin".
-// Inlined here so this file is independent of the user-management PR.
-func requireAdmin(c *gin.Context) bool {
-	cs, ok := c.Get("decoded_jwt")
-	if ok {
-		if claims, ok := cs.(*model.Claims); ok && claims != nil && claims.Role == "admin" {
-			return true
-		}
-	}
-	c.JSON(http.StatusForbidden, gin.H{"error": "admin role required"})
-	return false
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// GET /api/v2/zatca/monitor/stats
-// ──────────────────────────────────────────────────────────────────────────────
-
 // ZatcaMonitorStats returns aggregated submission counters across all branches.
 func (h *handler) ZatcaMonitorStats(c *gin.Context) {
-	if !requireAdmin(c) {
-		return
-	}
-
-	row := h.DB.QueryRow(`
-        SELECT
-          COUNT(*)                                                    AS total,
-          COUNT(CASE WHEN status = 2 THEN 1 END)                      AS accepted,
-          COUNT(CASE WHEN status = 4 THEN 1 END)                      AS warnings,
-          COUNT(CASE WHEN status = 3 THEN 1 END)                      AS rejected,
-          COUNT(CASE WHEN status IN (0, 1) THEN 1 END)                AS pending
-        FROM zatca_submission`)
-	var total, accepted, warnings, rejected, pending int64
-	if err := row.Scan(&total, &accepted, &warnings, &rejected, &pending); err != nil {
+	row, err := h.queries.GetZatcaMonitorStats(c.Request.Context())
+	if err != nil {
 		log.Printf("ZatcaMonitorStats: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load stats"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrZatcaLoadStats})
 		return
 	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"total_submitted": total,
-		"accepted":        accepted,
-		"warnings":        warnings,
-		"rejected":        rejected,
-		"pending":         pending,
+	c.JSON(http.StatusOK, model.ZatcaMonitorStats{
+		TotalSubmitted: row.Total,
+		Accepted:       row.Accepted,
+		Warnings:       row.Warnings,
+		Rejected:       row.Rejected,
+		Pending:        row.Pending,
 	})
-}
-
-// ──────────────────────────────────────────────────────────────────────────────
-// GET /api/v2/zatca/monitor/branches
-// ──────────────────────────────────────────────────────────────────────────────
-
-// zatcaBranchRow is the JSON shape returned for each onboarded branch.
-type zatcaBranchRow struct {
-	BranchID         int64    `json:"branch_id"`
-	BranchName       string   `json:"branch_name"`
-	ZatcaStatus      int      `json:"zatca_status"`
-	CertExpiry       *string  `json:"cert_expiry"`
-	TodayCount       int64    `json:"today_count"`
-	SuccessRate      float64  `json:"success_rate"`
-	LastSubmissionAt *string  `json:"last_submission_at"`
 }
 
 // ZatcaMonitorBranches returns one row per branch with a branch_zatca_config
 // entry, plus today's submission counts and 7-day success rate.
 func (h *handler) ZatcaMonitorBranches(c *gin.Context) {
-	if !requireAdmin(c) {
-		return
-	}
-
-	rows, err := h.DB.Query(`
-        SELECT
-          b.id,
-          b.name,
-          bzc.zatca_status,
-          bzc.zatca_compliance_certificate,
-          (SELECT COUNT(*)
-             FROM zatca_submission zs
-             JOIN bill bl ON bl.id = zs.bill_id
-             WHERE bl.branch_id = b.id
-               AND DATE(zs.submitted_at) = CURDATE())                   AS today_count,
-          (SELECT COUNT(*)
-             FROM zatca_submission zs
-             JOIN bill bl ON bl.id = zs.bill_id
-             WHERE bl.branch_id = b.id
-               AND zs.submitted_at >= NOW() - INTERVAL 7 DAY)           AS week_total,
-          (SELECT COUNT(*)
-             FROM zatca_submission zs
-             JOIN bill bl ON bl.id = zs.bill_id
-             WHERE bl.branch_id = b.id
-               AND zs.submitted_at >= NOW() - INTERVAL 7 DAY
-               AND zs.status = 2)                                       AS week_accepted,
-          (SELECT MAX(zs.submitted_at)
-             FROM zatca_submission zs
-             JOIN bill bl ON bl.id = zs.bill_id
-             WHERE bl.branch_id = b.id)                                 AS last_submission_at
-        FROM branches b
-        JOIN branch_zatca_config bzc ON bzc.branch_id = b.id
-        ORDER BY b.id ASC`)
+	rows, err := h.queries.ListZatcaMonitorBranches(c.Request.Context())
 	if err != nil {
-		log.Printf("ZatcaMonitorBranches query: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load branches"})
+		log.Printf("ZatcaMonitorBranches: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrZatcaLoadBranches})
 		return
 	}
-	defer rows.Close()
 
-	out := make([]zatcaBranchRow, 0)
-	for rows.Next() {
-		var (
-			r           zatcaBranchRow
-			cert        sql.NullString
-			weekTotal   int64
-			weekAccept  int64
-			lastSub     sql.NullString
-		)
-		if err := rows.Scan(
-			&r.BranchID, &r.BranchName, &r.ZatcaStatus, &cert,
-			&r.TodayCount, &weekTotal, &weekAccept, &lastSub,
-		); err != nil {
-			log.Printf("ZatcaMonitorBranches scan: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan branches"})
-			return
+	out := make([]model.ZatcaBranchRow, 0, len(rows))
+	for _, r := range rows {
+		item := model.ZatcaBranchRow{
+			BranchID:    int64(r.BranchID),
+			BranchName:  r.BranchName,
+			ZatcaStatus: int(r.ZatcaStatus),
+			TodayCount:  r.TodayCount,
 		}
-		if weekTotal > 0 {
-			r.SuccessRate = float64(weekAccept) / float64(weekTotal) * 100.0
+		if r.WeekTotal > 0 {
+			item.SuccessRate = float64(r.WeekAccepted) / float64(r.WeekTotal) * 100.0
 		}
-		if exp := certExpiryDate(cert.String); exp != "" {
-			r.CertExpiry = &exp
+		if r.Certificate != nil {
+			if exp := certExpiryDate(*r.Certificate); exp != "" {
+				item.CertExpiry = &exp
+			}
 		}
-		if lastSub.Valid {
-			v := lastSub.String
-			r.LastSubmissionAt = &v
+		if t, ok := lastSubmissionTime(r.LastSubmissionAt); ok {
+			s := t.Format(time.RFC3339)
+			item.LastSubmissionAt = &s
 		}
-		out = append(out, r)
+		out = append(out, item)
 	}
 	c.JSON(http.StatusOK, out)
+}
+
+// lastSubmissionTime extracts a time.Time from sqlc's `interface{}` column for
+// MAX(submitted_at). The driver returns either time.Time or []byte depending
+// on driver flags.
+func lastSubmissionTime(v interface{}) (time.Time, bool) {
+	switch x := v.(type) {
+	case time.Time:
+		return x, !x.IsZero()
+	case *time.Time:
+		if x == nil {
+			return time.Time{}, false
+		}
+		return *x, !x.IsZero()
+	case []byte:
+		if t, err := time.Parse("2006-01-02 15:04:05", string(x)); err == nil {
+			return t, true
+		}
+	case string:
+		if t, err := time.Parse("2006-01-02 15:04:05", x); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
 }
 
 // certExpiryDate parses an X.509 certificate and returns its NotAfter as
@@ -185,151 +124,119 @@ func certExpiryDate(s string) string {
 	return cert.NotAfter.Format("2006-01-02")
 }
 
-// ──────────────────────────────────────────────────────────────────────────────
-// GET /api/v2/zatca/monitor/submissions
-// ──────────────────────────────────────────────────────────────────────────────
-
 // statusToString converts the numeric submission status into the labels the
 // frontend uses.
 func statusToString(s int) string {
 	switch s {
-	case 2:
-		return "accepted"
-	case 3:
-		return "rejected"
-	case 4:
-		return "warning"
-	case 0, 1:
-		return "pending"
+	case ZatcaStatusAccepted:
+		return ZatcaLabelAccepted
+	case ZatcaStatusRejected:
+		return ZatcaLabelRejected
+	case ZatcaStatusWarning:
+		return ZatcaLabelWarning
+	case ZatcaStatusPending, ZatcaStatusSubmitted:
+		return ZatcaLabelPending
 	default:
-		return "unknown"
+		return ZatcaLabelUnknown
 	}
 }
 
-// ZatcaMonitorSubmissions returns recent submissions, optionally filtered by
-// status (numeric or label) and branch_id, ordered by submitted_at DESC.
-func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
-	if !requireAdmin(c) {
-		return
-	}
-
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
-	if limit <= 0 || limit > 200 {
-		limit = 50
-	}
-
-	// Sentinel filters keep the SQL static for code-scanners (Sonar S2077).
-	pendingFlag := ""    // "y" => match status IN (0,1)
-	statusCode := -1     // -1 => no exact-status match
-	var branchID int64 = 0 // 0 => no branch filter
+// parseSubmissionFilters reads `status` and `branch_id` query params into the
+// sentinel-filter shape consumed by ListZatcaMonitorSubmissions. On failure
+// it writes a 400 response and returns ok=false.
+func parseSubmissionFilters(c *gin.Context) (pendingFlag string, statusCode int, branchID uint32, ok bool) {
+	pendingFlag = zatcaPendingFlagOff
+	statusCode = zatcaStatusCodeAny
+	branchID = zatcaBranchAny
 
 	if s := c.Query("status"); s != "" {
 		switch s {
-		case "accepted":
-			statusCode = 2
-		case "rejected":
-			statusCode = 3
-		case "warning":
-			statusCode = 4
-		case "pending":
-			pendingFlag = "y"
+		case ZatcaLabelAccepted:
+			statusCode = ZatcaStatusAccepted
+		case ZatcaLabelRejected:
+			statusCode = ZatcaStatusRejected
+		case ZatcaLabelWarning:
+			statusCode = ZatcaStatusWarning
+		case ZatcaLabelPending:
+			pendingFlag = zatcaPendingFlagOn
 		default:
 			n, err := strconv.Atoi(s)
 			if err != nil {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
-				return
+				log.Printf("ZatcaMonitorSubmissions: invalid status %q: %v", s, err)
+				c.JSON(http.StatusBadRequest, gin.H{"error": ErrZatcaInvalidStatus})
+				return "", 0, 0, false
 			}
 			statusCode = n
 		}
 	}
 	if bs := c.Query("branch_id"); bs != "" {
-		bid, err := strconv.ParseInt(bs, 10, 64)
+		bid, err := strconv.ParseUint(bs, 10, 32)
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid branch_id"})
-			return
+			log.Printf("ZatcaMonitorSubmissions: invalid branch_id %q: %v", bs, err)
+			c.JSON(http.StatusBadRequest, gin.H{"error": ErrZatcaInvalidBranch})
+			return "", 0, 0, false
 		}
-		branchID = bid
+		branchID = uint32(bid)
+	}
+	return pendingFlag, statusCode, branchID, true
+}
+
+// ZatcaMonitorSubmissions returns recent submissions, optionally filtered by
+// status (numeric or label) and branch_id, ordered by submitted_at DESC.
+func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", strconv.Itoa(zatcaSubmissionsHint)))
+	if limit <= 0 || limit > zatcaSubmissionsCap {
+		limit = zatcaSubmissionsHint
 	}
 
-	rows, err := h.DB.Query(`
-        SELECT
-          bl.id            AS invoice_id,
-          bl.sequence_number,
-          bl.branch_id,
-          COALESCE(b.name, '')  AS branch_name,
-          zs.status,
-          zs.rejection_code,
-          zs.rejection_msg,
-          zs.submitted_at
-        FROM zatca_submission zs
-        JOIN bill bl     ON bl.id = zs.bill_id
-        LEFT JOIN branches b ON b.id = bl.branch_id
-        WHERE (? = '' OR zs.status IN (0,1))
-          AND (? = -1 OR zs.status = ?)
-          AND (? = 0 OR bl.branch_id = ?)
-        ORDER BY zs.submitted_at DESC
-        LIMIT ?`,
-		pendingFlag, statusCode, statusCode, branchID, branchID, limit)
-	if err != nil {
-		log.Printf("ZatcaMonitorSubmissions query: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load submissions"})
+	pendingFlag, statusCode, branchID, ok := parseSubmissionFilters(c)
+	if !ok {
 		return
 	}
-	defer rows.Close()
 
-	type submissionRow struct {
-		InvoiceID    int64   `json:"invoice_id"`
-		InvoiceNo    string  `json:"invoice_no"`
-		BranchID     *int64  `json:"branch_id"`
-		BranchName   string  `json:"branch_name"`
-		Status       string  `json:"status"`
-		StatusCode   int     `json:"status_code"`
-		ZatcaRef     *string `json:"zatca_ref"`
-		WarningMsg   *string `json:"warning_msg"`
-		SubmittedAt  *string `json:"submitted_at"`
+	branchPtr := &branchID
+	rows, err := h.queries.ListZatcaMonitorSubmissions(c.Request.Context(), db.ListZatcaMonitorSubmissionsParams{
+		PendingFlag: pendingFlag,
+		StatusCode:  int8(statusCode),
+		BranchID:    branchPtr,
+		Limit:       int32(limit),
+	})
+	if err != nil {
+		log.Printf("ZatcaMonitorSubmissions: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": ErrZatcaLoadSubmissions})
+		return
 	}
 
-	out := make([]submissionRow, 0)
-	for rows.Next() {
-		var (
-			r          submissionRow
-			seq        sql.NullInt64
-			branchID   sql.NullInt64
-			rejCode    sql.NullString
-			rejMsg     sql.NullString
-			submitted  sql.NullString
-		)
-		if err := rows.Scan(
-			&r.InvoiceID, &seq, &branchID, &r.BranchName,
-			&r.StatusCode, &rejCode, &rejMsg, &submitted,
-		); err != nil {
-			log.Printf("ZatcaMonitorSubmissions scan: %v", err)
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan submissions"})
-			return
+	out := make([]model.ZatcaSubmissionRow, 0, len(rows))
+	for _, r := range rows {
+		item := model.ZatcaSubmissionRow{
+			InvoiceID:  int64(r.InvoiceID),
+			BranchName: r.BranchName,
+			StatusCode: int(r.Status),
+			Status:     statusToString(int(r.Status)),
 		}
-		r.Status = statusToString(r.StatusCode)
-		if seq.Valid {
-			r.InvoiceNo = "INV-" + strconv.FormatInt(seq.Int64, 10)
+		if r.SequenceNumber != nil {
+			item.InvoiceNo = "INV-" + strconv.FormatUint(*r.SequenceNumber, 10)
 		} else {
-			r.InvoiceNo = "INV-" + strconv.FormatInt(r.InvoiceID, 10)
+			item.InvoiceNo = "INV-" + strconv.FormatUint(r.InvoiceID, 10)
 		}
-		if branchID.Valid {
-			v := branchID.Int64
-			r.BranchID = &v
+		if r.BranchID != nil {
+			v := int64(*r.BranchID)
+			item.BranchID = &v
 		}
-		if rejCode.Valid {
-			v := rejCode.String
-			r.ZatcaRef = &v
+		if r.RejectionCode != nil {
+			v := *r.RejectionCode
+			item.ZatcaRef = &v
 		}
-		if rejMsg.Valid {
-			v := rejMsg.String
-			r.WarningMsg = &v
+		if r.RejectionMsg != nil {
+			v := *r.RejectionMsg
+			item.WarningMsg = &v
 		}
-		if submitted.Valid {
-			v := submitted.String
-			r.SubmittedAt = &v
+		if r.SubmittedAt != nil {
+			s := r.SubmittedAt.Format(time.RFC3339)
+			item.SubmittedAt = &s
 		}
-		out = append(out, r)
+		out = append(out, item)
 	}
 	c.JSON(http.StatusOK, out)
 }

--- a/pkg/handlers/zatca_monitor.go
+++ b/pkg/handlers/zatca_monitor.go
@@ -1,0 +1,339 @@
+package handlers
+
+// ZATCA submission monitor — read-only ops dashboard endpoints.
+//
+// Backed by:
+//   * zatca_submission (status, retry_count, submitted_at, cleared_at, ...)
+//   * branch_zatca_config (zatca_status, zatca_*_certificate, ...)
+//   * bill (branch_id, invoice_uuid, sequence_number, effective_date)
+//   * branches (id, name)
+//
+// Status enum (matches pkg/db/gen/dashboard.sql.go GetDashboardZATCAStats):
+//   0 = pending, 1 = submitted, 2 = accepted, 3 = rejected, 4 = warning
+//
+// All endpoints require the caller to be admin.
+
+import (
+	"crypto/x509"
+	"database/sql"
+	"encoding/base64"
+	"encoding/pem"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"ifritah/web-service-gin/pkg/model"
+)
+
+// requireAdmin aborts with 403 unless the JWT claims have role == "admin".
+// Inlined here so this file is independent of the user-management PR.
+func requireAdmin(c *gin.Context) bool {
+	cs, ok := c.Get("decoded_jwt")
+	if ok {
+		if claims, ok := cs.(*model.Claims); ok && claims != nil && claims.Role == "admin" {
+			return true
+		}
+	}
+	c.JSON(http.StatusForbidden, gin.H{"error": "admin role required"})
+	return false
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/v2/zatca/monitor/stats
+// ──────────────────────────────────────────────────────────────────────────────
+
+// ZatcaMonitorStats returns aggregated submission counters across all branches.
+func (h *handler) ZatcaMonitorStats(c *gin.Context) {
+	if !requireAdmin(c) {
+		return
+	}
+
+	row := h.DB.QueryRow(`
+        SELECT
+          COUNT(*)                                                    AS total,
+          COUNT(CASE WHEN status = 2 THEN 1 END)                      AS accepted,
+          COUNT(CASE WHEN status = 4 THEN 1 END)                      AS warnings,
+          COUNT(CASE WHEN status = 3 THEN 1 END)                      AS rejected,
+          COUNT(CASE WHEN status IN (0, 1) THEN 1 END)                AS pending
+        FROM zatca_submission`)
+	var total, accepted, warnings, rejected, pending int64
+	if err := row.Scan(&total, &accepted, &warnings, &rejected, &pending); err != nil {
+		log.Printf("ZatcaMonitorStats: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load stats"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"total_submitted": total,
+		"accepted":        accepted,
+		"warnings":        warnings,
+		"rejected":        rejected,
+		"pending":         pending,
+	})
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/v2/zatca/monitor/branches
+// ──────────────────────────────────────────────────────────────────────────────
+
+// zatcaBranchRow is the JSON shape returned for each onboarded branch.
+type zatcaBranchRow struct {
+	BranchID         int64    `json:"branch_id"`
+	BranchName       string   `json:"branch_name"`
+	ZatcaStatus      int      `json:"zatca_status"`
+	CertExpiry       *string  `json:"cert_expiry"`
+	TodayCount       int64    `json:"today_count"`
+	SuccessRate      float64  `json:"success_rate"`
+	LastSubmissionAt *string  `json:"last_submission_at"`
+}
+
+// ZatcaMonitorBranches returns one row per branch with a branch_zatca_config
+// entry, plus today's submission counts and 7-day success rate.
+func (h *handler) ZatcaMonitorBranches(c *gin.Context) {
+	if !requireAdmin(c) {
+		return
+	}
+
+	rows, err := h.DB.Query(`
+        SELECT
+          b.id,
+          b.name,
+          bzc.zatca_status,
+          bzc.zatca_compliance_certificate,
+          (SELECT COUNT(*)
+             FROM zatca_submission zs
+             JOIN bill bl ON bl.id = zs.bill_id
+             WHERE bl.branch_id = b.id
+               AND DATE(zs.submitted_at) = CURDATE())                   AS today_count,
+          (SELECT COUNT(*)
+             FROM zatca_submission zs
+             JOIN bill bl ON bl.id = zs.bill_id
+             WHERE bl.branch_id = b.id
+               AND zs.submitted_at >= NOW() - INTERVAL 7 DAY)           AS week_total,
+          (SELECT COUNT(*)
+             FROM zatca_submission zs
+             JOIN bill bl ON bl.id = zs.bill_id
+             WHERE bl.branch_id = b.id
+               AND zs.submitted_at >= NOW() - INTERVAL 7 DAY
+               AND zs.status = 2)                                       AS week_accepted,
+          (SELECT MAX(zs.submitted_at)
+             FROM zatca_submission zs
+             JOIN bill bl ON bl.id = zs.bill_id
+             WHERE bl.branch_id = b.id)                                 AS last_submission_at
+        FROM branches b
+        JOIN branch_zatca_config bzc ON bzc.branch_id = b.id
+        ORDER BY b.id ASC`)
+	if err != nil {
+		log.Printf("ZatcaMonitorBranches query: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load branches"})
+		return
+	}
+	defer rows.Close()
+
+	out := make([]zatcaBranchRow, 0)
+	for rows.Next() {
+		var (
+			r           zatcaBranchRow
+			cert        sql.NullString
+			weekTotal   int64
+			weekAccept  int64
+			lastSub     sql.NullString
+		)
+		if err := rows.Scan(
+			&r.BranchID, &r.BranchName, &r.ZatcaStatus, &cert,
+			&r.TodayCount, &weekTotal, &weekAccept, &lastSub,
+		); err != nil {
+			log.Printf("ZatcaMonitorBranches scan: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan branches"})
+			return
+		}
+		if weekTotal > 0 {
+			r.SuccessRate = float64(weekAccept) / float64(weekTotal) * 100.0
+		}
+		if exp := certExpiryDate(cert.String); exp != "" {
+			r.CertExpiry = &exp
+		}
+		if lastSub.Valid {
+			v := lastSub.String
+			r.LastSubmissionAt = &v
+		}
+		out = append(out, r)
+	}
+	c.JSON(http.StatusOK, out)
+}
+
+// certExpiryDate parses an X.509 certificate and returns its NotAfter as
+// "YYYY-MM-DD". Accepts either a PEM block or a base64-encoded DER blob (ZATCA
+// returns the production cert base64-encoded). Returns "" on any parse error.
+func certExpiryDate(s string) string {
+	if s == "" {
+		return ""
+	}
+	var der []byte
+	if block, _ := pem.Decode([]byte(s)); block != nil {
+		der = block.Bytes
+	} else if raw, err := base64.StdEncoding.DecodeString(s); err == nil {
+		der = raw
+	} else {
+		return ""
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return ""
+	}
+	return cert.NotAfter.Format("2006-01-02")
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// GET /api/v2/zatca/monitor/submissions
+// ──────────────────────────────────────────────────────────────────────────────
+
+// statusToString converts the numeric submission status into the labels the
+// frontend uses.
+func statusToString(s int) string {
+	switch s {
+	case 2:
+		return "accepted"
+	case 3:
+		return "rejected"
+	case 4:
+		return "warning"
+	case 0, 1:
+		return "pending"
+	default:
+		return "unknown"
+	}
+}
+
+// ZatcaMonitorSubmissions returns recent submissions, optionally filtered by
+// status (numeric or label) and branch_id, ordered by submitted_at DESC.
+func (h *handler) ZatcaMonitorSubmissions(c *gin.Context) {
+	if !requireAdmin(c) {
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+
+	args := []any{}
+	where := "WHERE 1=1"
+
+	if s := c.Query("status"); s != "" {
+		// Accept either the numeric code or the string label.
+		statusCode := -1
+		switch s {
+		case "accepted":
+			statusCode = 2
+		case "rejected":
+			statusCode = 3
+		case "warning":
+			statusCode = 4
+		case "pending":
+			// pending covers 0 and 1
+			where += " AND zs.status IN (0,1)"
+		default:
+			if n, err := strconv.Atoi(s); err == nil {
+				statusCode = n
+			} else {
+				c.JSON(http.StatusBadRequest, gin.H{"error": "invalid status"})
+				return
+			}
+		}
+		if statusCode >= 0 {
+			where += " AND zs.status = ?"
+			args = append(args, statusCode)
+		}
+	}
+	if bs := c.Query("branch_id"); bs != "" {
+		bid, err := strconv.ParseInt(bs, 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid branch_id"})
+			return
+		}
+		where += " AND bl.branch_id = ?"
+		args = append(args, bid)
+	}
+	args = append(args, limit)
+
+	rows, err := h.DB.Query(`
+        SELECT
+          bl.id            AS invoice_id,
+          bl.sequence_number,
+          bl.branch_id,
+          COALESCE(b.name, '')  AS branch_name,
+          zs.status,
+          zs.rejection_code,
+          zs.rejection_msg,
+          zs.submitted_at
+        FROM zatca_submission zs
+        JOIN bill bl     ON bl.id = zs.bill_id
+        LEFT JOIN branches b ON b.id = bl.branch_id
+        `+where+`
+        ORDER BY zs.submitted_at DESC
+        LIMIT ?`, args...)
+	if err != nil {
+		log.Printf("ZatcaMonitorSubmissions query: %v", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load submissions"})
+		return
+	}
+	defer rows.Close()
+
+	type submissionRow struct {
+		InvoiceID    int64   `json:"invoice_id"`
+		InvoiceNo    string  `json:"invoice_no"`
+		BranchID     *int64  `json:"branch_id"`
+		BranchName   string  `json:"branch_name"`
+		Status       string  `json:"status"`
+		StatusCode   int     `json:"status_code"`
+		ZatcaRef     *string `json:"zatca_ref"`
+		WarningMsg   *string `json:"warning_msg"`
+		SubmittedAt  *string `json:"submitted_at"`
+	}
+
+	out := make([]submissionRow, 0)
+	for rows.Next() {
+		var (
+			r          submissionRow
+			seq        sql.NullInt64
+			branchID   sql.NullInt64
+			rejCode    sql.NullString
+			rejMsg     sql.NullString
+			submitted  sql.NullString
+		)
+		if err := rows.Scan(
+			&r.InvoiceID, &seq, &branchID, &r.BranchName,
+			&r.StatusCode, &rejCode, &rejMsg, &submitted,
+		); err != nil {
+			log.Printf("ZatcaMonitorSubmissions scan: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to scan submissions"})
+			return
+		}
+		r.Status = statusToString(r.StatusCode)
+		if seq.Valid {
+			r.InvoiceNo = "INV-" + strconv.FormatInt(seq.Int64, 10)
+		} else {
+			r.InvoiceNo = "INV-" + strconv.FormatInt(r.InvoiceID, 10)
+		}
+		if branchID.Valid {
+			v := branchID.Int64
+			r.BranchID = &v
+		}
+		if rejCode.Valid {
+			v := rejCode.String
+			r.ZatcaRef = &v
+		}
+		if rejMsg.Valid {
+			v := rejMsg.String
+			r.WarningMsg = &v
+		}
+		if submitted.Valid {
+			v := submitted.String
+			r.SubmittedAt = &v
+		}
+		out = append(out, r)
+	}
+	c.JSON(http.StatusOK, out)
+}

--- a/pkg/model/zatca_monitor.go
+++ b/pkg/model/zatca_monitor.go
@@ -1,0 +1,38 @@
+package model
+
+// Response shapes for the ZATCA submission monitor (read-only ops dashboard).
+// Backed by handlers in pkg/handlers/zatca_monitor.go.
+
+// ZatcaMonitorStats is the aggregated submission counter response for
+// GET /zatca/monitor/stats.
+type ZatcaMonitorStats struct {
+	TotalSubmitted int64 `json:"total_submitted"`
+	Accepted       int64 `json:"accepted"`
+	Warnings       int64 `json:"warnings"`
+	Rejected       int64 `json:"rejected"`
+	Pending        int64 `json:"pending"`
+}
+
+// ZatcaBranchRow is one row in the GET /zatca/monitor/branches response.
+type ZatcaBranchRow struct {
+	BranchID         int64   `json:"branch_id"`
+	BranchName       string  `json:"branch_name"`
+	ZatcaStatus      int     `json:"zatca_status"`
+	CertExpiry       *string `json:"cert_expiry"`
+	TodayCount       int64   `json:"today_count"`
+	SuccessRate      float64 `json:"success_rate"`
+	LastSubmissionAt *string `json:"last_submission_at"`
+}
+
+// ZatcaSubmissionRow is one row in the GET /zatca/monitor/submissions response.
+type ZatcaSubmissionRow struct {
+	InvoiceID   int64   `json:"invoice_id"`
+	InvoiceNo   string  `json:"invoice_no"`
+	BranchID    *int64  `json:"branch_id"`
+	BranchName  string  `json:"branch_name"`
+	Status      string  `json:"status"`
+	StatusCode  int     `json:"status_code"`
+	ZatcaRef    *string `json:"zatca_ref"`
+	WarningMsg  *string `json:"warning_msg"`
+	SubmittedAt *string `json:"submitted_at"`
+}


### PR DESCRIPTION
## Summary

Adds the read-only ZATCA submission monitor API requested in `_BACKEND_TODO.md`. The frontend can now power the ops dashboard with real data instead of the mocks it had before.

## Endpoints (admin only)

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/v2/zatca/monitor/stats` | aggregate counters (total / accepted / warnings / rejected / pending) |
| GET | `/api/v2/zatca/monitor/branches` | per-branch zatca_status, today's count, 7-day success rate, last submission time, production-cert expiry |
| GET | `/api/v2/zatca/monitor/submissions?limit=&status=&branch_id=` | recent submission log (limit ≤ 200, ordered by submitted_at DESC) |

## Status enum

Matches `pkg/db/gen/dashboard.sql.go::GetDashboardZATCAStats`:

- `0`, `1` → `pending`
- `2` → `accepted`
- `3` → `rejected`
- `4` → `warning`

The `submissions` endpoint accepts both numeric codes and these labels for the `status` filter.

## Implementation notes

- `cert_expiry` reads `branch_zatca_config.zatca_compliance_certificate` and returns the X.509 `NotAfter` as `YYYY-MM-DD`. The cert is stored either PEM-encoded or as a base64 DER blob (depends on the onboarding path); both are decoded. Returns `null` on parse failure rather than 500-ing the whole response.
- 7-day success rate = `count(status=2) / count(*)` over the last 7 days, scoped by `bill.branch_id`.
- Inlines a small `requireAdmin` helper so this PR is independent of the user-management PR (PR #12). Once that lands the helper can be replaced by the shared `requireRole`.

## Schema dependencies

No migration. Uses existing tables: `zatca_submission`, `branch_zatca_config`, `bill`, `branches`.

## Drive-by build fix

`getPurchaseBills` was declared `[]db.PurchaseBillTotal` on dev but the sqlc method returns `[]db.PurchaseBill` (totals view dropped in PR #9). Same one-line fix is also in PRs #11 and #12; whichever lands first is fine.

## Verification

- `go build ./...` clean.
- Spot-checked queries against the local dev DB; they execute and return the expected (currently empty) shapes.

## Out of scope

- Live drilldown views for individual submissions (XML payload / retry button) — frontend not asking for those yet.
