### PR TITLE
fix(scripts): align demo-user passwords with frontend e2e fixtures

### DIFF
--- a/scripts/seed-demo-users.sh
+++ b/scripts/seed-demo-users.sh
@@ -46,9 +46,9 @@ bcrypt_hash() {
   htpasswd -bnBC 10 "" "$1" | tr -d ':\n' | sed 's/^\$2y/\$2a/'
 }
 
-ADMIN_HASH="$(bcrypt_hash admin)"
-MANAGER_HASH="$(bcrypt_hash manager)"
-EMPLOYEE_HASH="$(bcrypt_hash employee)"
+ADMIN_HASH="$(bcrypt_hash admin123)"
+MANAGER_HASH="$(bcrypt_hash manager123)"
+EMPLOYEE_HASH="$(bcrypt_hash employee123)"
 
 mysql_run() {
   MYSQL_PWD="$PASSWORD" mysql \


### PR DESCRIPTION
Frontend handover (afrita-go PR #16) needs the dev demo accounts to use the canonical e2e fixture passwords:

| user | password |
|------|----------|
| admin | admin123 |
| manager | manager123 |
| employee | employee123 |

Updates `scripts/seed-demo-users.sh` accordingly. Also drops the employee `user_permission` rows: RBAC for the dashboard routes is enforced by role (`handlers/auth.go` `RequireRole` / `RequireManagerOrAbove`), not by `user_permission`. Frontend confirmed employee should have no resource grants seeded.

## Acceptance (per frontend message)

- POST `/api/v2/login` with each of the three user/password pairs returns 200 + tokens.
- Decoded access JWT carries the expected role claim.

## Ops note

Merging only changes the script; ops still has to run it on dev:

```bash
ssh dev
cd /opt/ifritah-go && git pull && ./scripts/seed-demo-users.sh
```