### PR TITLE
fix(scope): default empty store_ids; seed demo company + stores

### DIFF
--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -62,7 +62,6 @@ func (h *handler) GetBills(c *gin.Context) {
 	}
 
 	request := model.BillRequestFilter{
-		StoreIds: storeIds,
 		Page:     0,
 		PageSize: 10,
 	}
@@ -73,8 +72,19 @@ func (h *handler) GetBills(c *gin.Context) {
 		return
 	}
 
-	if request.Page < 0 || request.PageSize <= 0 || request.StoreIds == nil || len(request.StoreIds) == 0 {
+	if request.Page < 0 || request.PageSize <= 0 {
 		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	// store_ids is a filter, not a primary key. When omitted, default to
+	// every store the caller can access. Truly no accessible stores means
+	// "empty result", not "bad request".
+	if len(request.StoreIds) == 0 {
+		request.StoreIds = storeIds
+	}
+	if len(request.StoreIds) == 0 {
+		c.JSON(http.StatusOK, []any{})
 		return
 	}
 

--- a/pkg/handlers/purchase_bill.go
+++ b/pkg/handlers/purchase_bill.go
@@ -338,7 +338,6 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 	}
 
 	request := model.BillRequestFilter{
-		StoreIds: storeIds,
 		Page:     0,
 		PageSize: 10,
 	}
@@ -349,8 +348,19 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 		return
 	}
 
-	if request.Page < 0 || request.PageSize <= 0 || request.StoreIds == nil || len(request.StoreIds) == 0 {
+	if request.Page < 0 || request.PageSize <= 0 {
 		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	// store_ids is a filter, not a primary key. When omitted, default to
+	// every store the caller can access. Truly no accessible stores means
+	// "empty result", not "bad request".
+	if len(request.StoreIds) == 0 {
+		request.StoreIds = storeIds
+	}
+	if len(request.StoreIds) == 0 {
+		c.JSON(http.StatusOK, []any{})
 		return
 	}
 

--- a/scripts/seed-demo-users.sh
+++ b/scripts/seed-demo-users.sh
@@ -73,6 +73,31 @@ ON DUPLICATE KEY UPDATE
   role      = VALUES(role),
   is_active = 1;
 
+-- ---- demo company + stores (idempotent) ---------------------------------
+-- A user with no company_id has no accessible stores, which makes every
+-- list endpoint that scopes by store return 400. Attach the three demo
+-- accounts to a single "Demo Co" with two stores so the e2e suite can
+-- exercise multi-branch flows.
+SET @company_id = (SELECT id FROM company WHERE name = 'Demo Co' LIMIT 1);
+INSERT INTO company (name, vat_number)
+SELECT 'Demo Co', '300000000000003'
+WHERE @company_id IS NULL;
+SET @company_id = (SELECT id FROM company WHERE name = 'Demo Co' LIMIT 1);
+
+UPDATE user SET company_id = @company_id
+ WHERE username IN ('admin','manager','employee');
+
+INSERT INTO store (company_id, name)
+SELECT @company_id, 'Demo Store 1'
+WHERE NOT EXISTS (
+  SELECT 1 FROM store WHERE company_id = @company_id AND name = 'Demo Store 1'
+);
+INSERT INTO store (company_id, name)
+SELECT @company_id, 'Demo Store 2'
+WHERE NOT EXISTS (
+  SELECT 1 FROM store WHERE company_id = @company_id AND name = 'Demo Store 2'
+);
+
 -- ---- view-only permissions for the employee account ---------------------
 -- Admin/manager bypass row grants by role.
 INSERT INTO user_permission (user_id, resource, can_view, can_add, can_edit, can_delete)


### PR DESCRIPTION
Fixes frontend P1 reported in chat/2026-05-02_frontend-to-backend_list-endpoints-400.md.

## Why

New demo users seeded by PR #21 had no company_id and no rows in store. POST /api/v2/bill/all and /api/v2/purchase_bill/all then answered 400 because the handlers treated an empty store_ids filter as a bad request. Frontend mitigated locally by treating those 400s as empty lists, but the contract was wrong.

## Changes

**pkg/handlers/bill.go, pkg/handlers/purchase_bill.go**
- store_ids is a filter, not a primary key.
- Omitted -> default to caller's accessible stores.
- Caller has zero accessible stores -> 200 [] (empty list).
- store_ids referencing a store the caller cannot access -> still 400.

**scripts/seed-demo-users.sh**
- Idempotently insert `Demo Co` (matched by name; falls back to INSERT when missing).
- Attach admin / manager / employee to that company.
- Idempotently insert `Demo Store 1` and `Demo Store 2`.

## Out of scope

Frontend also asked about /supplier/{id}/report/export-csv and /export-excel returning 500. Those routes are not registered on the backend (only GET /supplier/:id/report exists). Replying separately in chat/.