### PR TITLE
fix(docker): regenerate sqlc in build stage; keep config.go in context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,10 @@
 docker-compose*.yml
 saas_multi_tenant
 pkg/db/gen
+# config.go is hand-written (db connection helper) and lives alongside the
+# sqlc-generated output. Keep it in the build context so the Go build can
+# resolve `db.Connect`.
+!pkg/db/gen/config.go
 **/*.pdf
 ifritah
 ifritah.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,19 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 
+# pkg/db/gen is gitignored and produced by `sqlc generate`. Bake the
+# generation step into the image so the build does not depend on local
+# state — pkg/db/gen is .dockerignore'd because it is .gitignore'd, so
+# without this step CI fails with "package .../pkg/db/gen is not in std".
+RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.27.0
+
 # Copy only the inputs needed to build the binary. Avoids a recursive
 # `COPY . .` which can leak local state into the image (Sonar docker:S6470).
 COPY main.go ./
 COPY pkg ./pkg
 COPY fonts ./fonts
 COPY sqlc.yaml ./
+RUN sqlc generate
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/ifritah .
 
 # ---- Runtime stage ----


### PR DESCRIPTION
Fixes the failing "Build & Push Backend" workflow on dev (run 25249088749) flagged by frontend.

## Why it was broken

pkg/db/gen is gitignored (sqlc output) and the entire directory was also in .dockerignore. The Dockerfile copied pkg/ into the builder but never regenerated sqlc, so go build failed:

"""
package ifritah/web-service-gin/pkg/db/gen is not in std
"""

## Fix (two parts, both required)

1. Dockerfile: go install sqlc v1.27.0 in the builder stage and run sqlc generate before go build. Image is now self-contained.
2. .dockerignore: re-include pkg/db/gen/config.go (the hand-written DB-connection helper that sits next to the generated files and is the only git-tracked file in that dir). Without it, build fails with undefined: db.Connect.

## Verified

docker build -t ifritah-api:test . exits 0 locally on the same dev HEAD.