### PR TITLE
chore(seed): extend demo dataset for e2e fixtures (15 skipped specs)

### DIFF
--- a/scripts/seed-demo-users.sh
+++ b/scripts/seed-demo-users.sh
@@ -113,6 +113,115 @@ CROSS JOIN (
 ) r
 WHERE u.username = 'employee'
 ON DUPLICATE KEY UPDATE can_view = 1;
+
+-- ---- demo dataset for e2e fixtures (idempotent) -------------------------
+-- The Playwright suite needs at least one row in several tables to
+-- exercise list/edit/search flows. Each block below is keyed on a stable
+-- natural identifier so re-running the script never duplicates rows.
+--
+-- merchant_id in this codebase is the creator user.id (see
+-- pkg/handlers/cash_vouchar.go: getMerchantID == GetSessionInfo.id), so
+-- everything seeded here is owned by the admin demo account.
+SET @admin_id    = (SELECT id FROM user  WHERE username = 'admin' LIMIT 1);
+SET @store_id    = (SELECT id FROM store WHERE company_id = @company_id AND name = 'Demo Store 1' LIMIT 1);
+
+-- 3 products in Demo Store 1 with realistic stock for stock-enforcement tests.
+-- UNIQUE (article_id, store_id) makes the upsert idempotent.
+INSERT INTO product (article_id, store_id, name, price, quantity, min_stock, cost_price)
+VALUES
+  (9001, @store_id, 'OEM Filter A',     45.00,  20.000, 5,  20.00),
+  (9002, @store_id, 'Battery Pack B',  320.00,  10.000, 3, 220.00),
+  (9003, @store_id, 'Spark Plug Set',   60.00,   5.000, 5,  25.00)
+ON DUPLICATE KEY UPDATE
+  name       = VALUES(name),
+  price      = VALUES(price),
+  quantity   = VALUES(quantity),
+  min_stock  = VALUES(min_stock),
+  cost_price = VALUES(cost_price);
+
+-- 1 client (vat_number is NOT NULL; format check is on company.vat_number,
+-- not client.vat_number). Keyed by vat_number so re-runs don't duplicate.
+INSERT INTO client (name, company_name, phone, address, vat_number, country)
+SELECT 'ACME Trading Co', 'ACME Trading Co', '0500000001',
+       'Demo HQ, Riyadh', '300000000000099', 'SA'
+WHERE NOT EXISTS (
+  SELECT 1 FROM client WHERE vat_number = '300000000000099'
+);
+SET @client_id = (SELECT id FROM client WHERE vat_number = '300000000000099' LIMIT 1);
+
+-- 1 supplier under Demo Co. Keyed by (company_id, name).
+INSERT INTO supplier (company_id, name, phone_number, address, vat_number)
+SELECT @company_id, 'Demo Supplier', '0500000002', 'Demo Warehouse, Riyadh',
+       '300000000000088'
+WHERE NOT EXISTS (
+  SELECT 1 FROM supplier
+   WHERE company_id = @company_id AND name = 'Demo Supplier'
+);
+SET @supplier_id = (
+  SELECT id FROM supplier
+   WHERE company_id = @company_id AND name = 'Demo Supplier'
+   LIMIT 1
+);
+
+-- 1 company-mode draft invoice (state=0, client_id set).
+-- Keyed by note='DEMO_SEED_INVOICE' so re-runs don't duplicate.
+INSERT INTO bill (state, client_id, store_id, merchant_id, discount,
+                  maintenance_cost, note, payment_method, userName)
+SELECT 0, @client_id, @store_id, @admin_id, 0, 0,
+       'DEMO_SEED_INVOICE', 10, 'Demo Admin'
+WHERE NOT EXISTS (
+  SELECT 1 FROM bill WHERE note = 'DEMO_SEED_INVOICE'
+);
+SET @bill_id = (SELECT id FROM bill WHERE note = 'DEMO_SEED_INVOICE' LIMIT 1);
+
+-- 1 line item on the demo invoice (only when the line doesn't exist yet).
+INSERT INTO bill_product (product_id, bill_id, vat, price, quantity, name)
+SELECT p.id, @bill_id, 15.00, 45.00, 1.000, 'OEM Filter A'
+FROM product p
+WHERE p.article_id = 9001 AND p.store_id = @store_id
+  AND NOT EXISTS (
+    SELECT 1 FROM bill_product WHERE bill_id = @bill_id
+  );
+
+-- 1 draft purchase bill so /dashboard/purchase-bills/edit/{id} is reachable.
+-- Keyed via the unique (supplier_id, supplier_sequence_number) constraint.
+INSERT INTO purchase_bill (state, supplier_id, store_id, merchant_id,
+                           discount, payment_method, supplier_sequence_number)
+SELECT 0, @supplier_id, @store_id, @admin_id, 0, 10, 9001
+WHERE @supplier_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM purchase_bill
+     WHERE supplier_id = @supplier_id AND supplier_sequence_number = 9001
+  );
+SET @pb_id = (
+  SELECT id FROM purchase_bill
+   WHERE supplier_id = @supplier_id AND supplier_sequence_number = 9001
+   LIMIT 1
+);
+
+INSERT INTO purchase_bill_product (product_id, bill_id, vat, price, quantity, name)
+SELECT p.id, @pb_id, 15.00, 20.00, 5.000, 'OEM Filter A'
+FROM product p
+WHERE @pb_id IS NOT NULL
+  AND p.article_id = 9001 AND p.store_id = @store_id
+  AND NOT EXISTS (
+    SELECT 1 FROM purchase_bill_product WHERE bill_id = @pb_id
+  );
+
+-- 1 cash voucher with a stable, searchable recipient_name.
+-- voucher_number is per-merchant; 9001 is far above the auto-allocated
+-- range, so it will not collide with normal app activity.
+INSERT INTO cash_voucher (voucher_number, voucher_type, amount, payment_method,
+                          state, recipient_type, recipient_name, description,
+                          store_id, merchant_id, created_by)
+SELECT 9001, 'disbursement', 100.00, 'cash', 0, 'other',
+       'DEMO RECIPIENT QA', 'Seed voucher for qa-20 search needle',
+       @store_id, @admin_id, @admin_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM cash_voucher
+   WHERE merchant_id = @admin_id AND recipient_name = 'DEMO RECIPIENT QA'
+);
 SQL
 
 echo "[seed] demo users ensured: admin / manager / employee"
+echo "[seed] demo dataset ensured: 3 products, 1 client, 1 supplier, 1 invoice, 1 purchase bill, 1 cash voucher"


### PR DESCRIPTION
Closes the 15 `test.skip()` guards reported in chat/2026-05-02_frontend-to-backend_demo-seed-coverage.md.

## Why

After PR #23 + #24 the FE suite was 230/0/15 (passed/failed/skipped). The skips were all "spec needs a fixture row that the dev DB does not have." This PR lands those rows in the existing seed script.

## What `./scripts/seed-demo-users.sh` now ensures (in addition to users/company/stores)

- **3 products** in Demo Store 1 (article_id 9001..9003) with realistic stock levels — needed for `qa-15-stock-enforcement-behavior` (×4) and the products-search needle in `/api/products/search-json?query=a`.
- **1 client** (`ACME Trading Co`, vat_number `300000000000099`) — needed for the company-mode draft invoice below.
- **1 supplier** (`Demo Supplier`) under Demo Co.
- **1 draft (state=0) invoice** keyed by `note='DEMO_SEED_INVOICE'` with `client_id` set (i.e. company-mode) and 1 line item — needed for `qa-28-edit-roundtrip` invoice case.
- **1 draft purchase_bill** keyed by `(supplier_id, supplier_sequence_number=9001)` with 1 line item — needed for `qa-30-purchase-bill-stock-price-labels` edit case and `qa-28-edit-roundtrip` purchase-bill case.
- **1 cash_voucher** with `recipient_name='DEMO RECIPIENT QA'` so `qa-20-list-filters`'s `?q=` needle is deterministic.

Every block is keyed on a stable natural identifier (UNIQUE indexes where they exist, `WHERE NOT EXISTS` otherwise) so re-running the script leaves the row counts unchanged. Verified against local MySQL 8.

## Cash-voucher search — answer to FE's question

`GET /api/cash-vouchers?q=` matches on **`recipient_name` OR `description` OR `note`** (see `pkg/handlers/cash_vouchar.go` `ListCashVouchers`). The seed voucher's recipient_name + description both contain the literal `DEMO RECIPIENT QA`, so the qa-20 needle picker can target either field.

## Ops

After merge, re-run `./scripts/seed-demo-users.sh` on dev. FE should be able to drop the corresponding `test.skip()` guards.