### PR TITLE
chore(seed): add issued invoice + demo order, fix company-mode draft

### DIFF
--- a/scripts/seed-demo-users.sh
+++ b/scripts/seed-demo-users.sh
@@ -163,24 +163,54 @@ SET @supplier_id = (
    LIMIT 1
 );
 
--- 1 company-mode draft invoice (state=0, client_id set).
+-- 1 company-mode draft invoice (state=0, client_id set, userName NULL).
+-- bill_type in the API is derived as `client_id IS NOT NULL`, so leaving
+-- userName NULL keeps the row unambiguously company-mode for qa-28.
 -- Keyed by note='DEMO_SEED_INVOICE' so re-runs don't duplicate.
 INSERT INTO bill (state, client_id, store_id, merchant_id, discount,
-                  maintenance_cost, note, payment_method, userName)
+                  maintenance_cost, note, payment_method)
 SELECT 0, @client_id, @store_id, @admin_id, 0, 0,
-       'DEMO_SEED_INVOICE', 10, 'Demo Admin'
+       'DEMO_SEED_INVOICE', 10
 WHERE NOT EXISTS (
   SELECT 1 FROM bill WHERE note = 'DEMO_SEED_INVOICE'
 );
+-- Migrate older seed rows (PR #25) that wrote userName=Demo Admin.
+UPDATE bill SET userName = NULL
+ WHERE note = 'DEMO_SEED_INVOICE' AND userName IS NOT NULL;
 SET @bill_id = (SELECT id FROM bill WHERE note = 'DEMO_SEED_INVOICE' LIMIT 1);
 
--- 1 line item on the demo invoice (only when the line doesn't exist yet).
+-- 1 line item on the demo draft invoice.
 INSERT INTO bill_product (product_id, bill_id, vat, price, quantity, name)
 SELECT p.id, @bill_id, 15.00, 45.00, 1.000, 'OEM Filter A'
 FROM product p
 WHERE p.article_id = 9001 AND p.store_id = @store_id
   AND NOT EXISTS (
     SELECT 1 FROM bill_product WHERE bill_id = @bill_id
+  );
+
+-- 1 issued (state=1) company-mode invoice — qa-17 credit-note round-trip
+-- needs an issued bill with no credit_note row yet (credit_state IS NULL,
+-- which is the default for any freshly-issued bill). Keyed by
+-- note='DEMO_SEED_ISSUED_INVOICE'.
+INSERT INTO bill (state, client_id, store_id, merchant_id, discount,
+                  maintenance_cost, note, payment_method,
+                  total_before_vat, total_vat, total)
+SELECT 1, @client_id, @store_id, @admin_id, 0, 0,
+       'DEMO_SEED_ISSUED_INVOICE', 10,
+       45.00, 6.75, 51.75
+WHERE NOT EXISTS (
+  SELECT 1 FROM bill WHERE note = 'DEMO_SEED_ISSUED_INVOICE'
+);
+SET @issued_bill_id = (
+  SELECT id FROM bill WHERE note = 'DEMO_SEED_ISSUED_INVOICE' LIMIT 1
+);
+
+INSERT INTO bill_product (product_id, bill_id, vat, price, quantity, name)
+SELECT p.id, @issued_bill_id, 15.00, 45.00, 1.000, 'OEM Filter A'
+FROM product p
+WHERE p.article_id = 9001 AND p.store_id = @store_id
+  AND NOT EXISTS (
+    SELECT 1 FROM bill_product WHERE bill_id = @issued_bill_id
   );
 
 -- 1 draft purchase bill so /dashboard/purchase-bills/edit/{id} is reachable.
@@ -211,6 +241,16 @@ WHERE @pb_id IS NOT NULL
 -- 1 cash voucher with a stable, searchable recipient_name.
 -- voucher_number is per-merchant; 9001 is far above the auto-allocated
 -- range, so it will not collide with normal app activity.
+-- 1 demo order so qa-28 order round-trip has a row to edit.
+-- sequence_number is UNIQUE, so it doubles as the natural key.
+INSERT INTO orders (sequence_number, client_id, customer_name, store_id,
+                    status, total, note, created_by)
+SELECT 'DEMO-ORD-001', @client_id, 'ACME Trading Co', @store_id,
+       'pending', 100.00, 'DEMO_SEED_ORDER', @admin_id
+WHERE NOT EXISTS (
+  SELECT 1 FROM orders WHERE sequence_number = 'DEMO-ORD-001'
+);
+
 INSERT INTO cash_voucher (voucher_number, voucher_type, amount, payment_method,
                           state, recipient_type, recipient_name, description,
                           store_id, merchant_id, created_by)
@@ -224,4 +264,4 @@ WHERE NOT EXISTS (
 SQL
 
 echo "[seed] demo users ensured: admin / manager / employee"
-echo "[seed] demo dataset ensured: 3 products, 1 client, 1 supplier, 1 invoice, 1 purchase bill, 1 cash voucher"
+echo "[seed] demo dataset ensured: 3 products, 1 client, 1 supplier, 1 draft + 1 issued invoice, 1 purchase bill, 1 order, 1 cash voucher"


### PR DESCRIPTION
Follow-up to chat/2026-05-02_frontend-to-backend_remaining-7-skips.md. Closes 3 of the 7 remaining e2e skips and tightens 1 fixture row that was being misclassified.

## Skips addressed

| Skip | Fix |
|---|---|
| `qa-17` credit-note round-trip | Seed now inserts a state=1 issued `bill` keyed by `note='DEMO_SEED_ISSUED_INVOICE'`. With no `credit_note` row attached, `credit_state IS NULL` (which is what the FE checks to render the credit link). |
| `qa-28` invoice round-trip (company-mode) | Existing `DEMO_SEED_INVOICE` draft already had `client_id` set, but it also had `userName='Demo Admin'` left over from PR #25. `bill_type` is derived as `client_id IS NOT NULL` server-side, but the FE picker disambiguates by absence of `userName`. Seed now inserts without it and back-fills existing rows to `userName=NULL`. |
| `qa-28` order round-trip | Seed now inserts a single `orders` row keyed by `sequence_number='DEMO-ORD-001'`. |

## Skips intentionally not addressed

- `qa-28` product round-trip: PR #25's seed already populates `product.store_id` (verified in local DB right after running it). FE was likely reading a pre-merge snapshot. No change needed; please re-verify after this PR runs on dev.
- `qa-28` cash voucher round-trip: the seeded voucher already has `voucher_type=disbursement`, `payment_method=cash`, `recipient_type=other`, `amount=100`, `effective_date` defaulting to NOW. All required fields are non-blank. If qa-28 still skips on CI after this lands, ping me — likely a render-side bug.
- `qa-28` user round-trip: requires backend `/api/v2/users` CRUD endpoints. That's a feature, not a seed gap. Tracking separately.
- qa-15 stock enforcement: already passing on CI per the FE note.

## Idempotency

Verified locally against MySQL 8.0: two consecutive runs of `./scripts/seed-demo-users.sh` produce identical row counts (3 products, 2 stores, 1 client, 1 supplier, 1 draft + 1 issued bill, 2 bill_products, 1 purchase_bill, 1 order, 1 cash_voucher).

## Ops

After merge, re-run `./scripts/seed-demo-users.sh` on dev. Expected FE result: **241 / 0 / 4** (only the 3 voucher/product non-issues + 1 user-CRUD skip remain, and we expect 0/3 of the non-issues to recur).