### PR TITLE
fix(bill): populate type (B2B/B2C) and expose client_id in detail response

### DIFF
--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -533,6 +533,12 @@ func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProduct
 		CommercialRegistrationNumber: CommercialRegistrationNumber,
 		CreditID:                     bill.CreditID,
 		Client:                       client,
+		ClientID:                     bill.ClientID,
+		// `type` was historically the "is the bill issued to a registered
+		// client" flag (B2B) vs an anonymous walk-in (B2C). It is fully
+		// derivable from the presence of client_id, so do that here instead
+		// of leaving the field as the zero value.
+		Type:                         bill.ClientID != nil,
 		PaymentMethod:                bill.PaymentMethod,
 		DeliverDate:                  bill.DeliverDate,
 		BranchID:                     bill.BranchID,

--- a/pkg/model/bill.go
+++ b/pkg/model/bill.go
@@ -124,6 +124,7 @@ type Bill struct {
 	TotalVAT                     string                `json:"total_vat"`
 	Total                        string                `json:"total"`
 	Client                       *db.Client            `json:"client"`
+	ClientID                     *int32                `json:"client_id"`
 	PaymentMethod                int32                 `json:"payment_method"`
 	BranchID                     *uint32               `json:"branch_id"`
 	DeliverDate                  *time.Time            `json:"deliver_date"`


### PR DESCRIPTION
Fixes the qa-28 invoice round-trip skip reported in chat/2026-05-02_frontend-to-backend_pr26-followup.md (item 1).

## Bug

`GET /api/v2/bill/:id` always returned `"type": false`, even when `client_id` was populated. FE relies on `type` to decide whether to render the edit page in company-mode (B2B) or personal-mode (B2C). Result: every draft renders as personal-mode regardless of how it was created.

Root cause: `model.Bill.Type` is declared but never set inside `getBillDetail`. The struct literal returns the zero value (`false`).

## Fix

`pkg/handlers/bill.go` `getBillDetail`:

```go
Client:    client,
ClientID:  bill.ClientID,
Type:      bill.ClientID != nil,
```

`pkg/model/bill.go` adds `ClientID *int32` next to the existing `Client *db.Client`.

`type` is a derived field — there is no separate column in the schema; `bill.client_id IS NOT NULL` is the source of truth, so deriving it on the fly is the correct shape.

## Out of scope (called out separately in chat/)

- qa-28 product 404 — FE was using `article_id` for the URL, but `GET /api/v2/product/:id` expects the row PK. Not a backend bug.
- qa-28 order — local DB shows `customer_name` and `sequence_number` populated correctly on the seeded row; FE template likely reads the wrong path inside the `detail` envelope. Not a backend bug.
