### PR TITLE
feat(pagination): keyset/cursor pagination across 9 list endpoints

### DIFF
--- a/pkg/db/migrations/0003_keyset_indexes.sql
+++ b/pkg/db/migrations/0003_keyset_indexes.sql
@@ -1,0 +1,70 @@
+-- ============================================================================
+-- 0003_keyset_indexes.sql
+-- Composite indexes that support keyset pagination on the list endpoints.
+--
+-- Why these specific indexes:
+--   The seek predicate is `WHERE (sort_value, id) < (?, ?)
+--                          ORDER BY sort_value DESC, id DESC LIMIT N+1`.
+--   For that to run as a single index range scan (no filesort, no temp
+--   table) we need an index whose leading columns match the ORDER BY.
+--   InnoDB silently appends the PK to every secondary index, so a key
+--   on `(effective_date)` already sorts ties by `id` for free — but
+--   declaring `(effective_date DESC, id DESC)` explicitly lets the
+--   optimizer use the index in the natural scan direction, avoiding a
+--   backward range scan that some older 8.0 minor versions still cost
+--   higher than a filesort. (MySQL 8.0+ supports descending indexes;
+--   we already pin to 8.0 in compose.)
+--
+-- The previously-shipped `(merchant_id, effective_date)` keys are kept
+-- — they are still useful for any per-creator queries (dashboards,
+-- audit). They do NOT serve the new list seek because `merchant_id`
+-- (which actually stores the creator user id, not a tenant id) is not
+-- in the WHERE clause of the new list queries.
+--
+-- Idempotent: same gate-on-information_schema pattern as 0002.
+-- ============================================================================
+
+-- bill ----------------------------------------------------------------------
+SET @s := IF(EXISTS(SELECT 1 FROM information_schema.statistics
+  WHERE table_schema=DATABASE() AND table_name='bill' AND index_name='idx_bill_keyset'),
+  'SELECT 1',
+  'ALTER TABLE `bill` ADD INDEX `idx_bill_keyset` (`effective_date` DESC, `id` DESC)');
+PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- purchase_bill -------------------------------------------------------------
+SET @s := IF(EXISTS(SELECT 1 FROM information_schema.statistics
+  WHERE table_schema=DATABASE() AND table_name='purchase_bill' AND index_name='idx_pb_keyset'),
+  'SELECT 1',
+  'ALTER TABLE `purchase_bill` ADD INDEX `idx_pb_keyset` (`effective_date` DESC, `id` DESC)');
+PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- cash_voucher --------------------------------------------------------------
+SET @s := IF(EXISTS(SELECT 1 FROM information_schema.statistics
+  WHERE table_schema=DATABASE() AND table_name='cash_voucher' AND index_name='idx_cv_keyset'),
+  'SELECT 1',
+  'ALTER TABLE `cash_voucher` ADD INDEX `idx_cv_keyset` (`effective_date` DESC, `id` DESC)');
+PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- orders --------------------------------------------------------------------
+-- Sorted by created_at DESC for the list page. Same DESC-DESC composite
+-- so the seek is one index range read.
+SET @s := IF(EXISTS(SELECT 1 FROM information_schema.statistics
+  WHERE table_schema=DATABASE() AND table_name='orders' AND index_name='idx_orders_keyset'),
+  'SELECT 1',
+  'ALTER TABLE `orders` ADD INDEX `idx_orders_keyset` (`created_at` DESC, `id` DESC)');
+PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- client --------------------------------------------------------------------
+-- Sorted by updated_at DESC, id DESC (matches existing GetClients ORDER BY
+-- and surfaces recently-touched clients first, the existing UX contract).
+SET @s := IF(EXISTS(SELECT 1 FROM information_schema.statistics
+  WHERE table_schema=DATABASE() AND table_name='client' AND index_name='idx_client_keyset'),
+  'SELECT 1',
+  'ALTER TABLE `client` ADD INDEX `idx_client_keyset` (`is_deleted`, `updated_at` DESC, `id` DESC)');
+PREPARE stmt FROM @s; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- supplier, product, branch, stores list pages all sort by `id DESC` only.
+-- The InnoDB primary key already serves that scan order natively — no
+-- additional index needed for the seek itself. The existing per-tenant
+-- filter indexes (idx_supplier_company_active, idx_product_store_active_qty)
+-- still match their respective handler filters.

--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -3,21 +3,23 @@
   values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetAllBill :many
--- Keyset / cursor pagination. Sort key: (effective_date DESC, id DESC).
--- The (cursor_date, cursor_id) sentinels are NULL on the first page and
--- non-NULL on subsequent pages; the OR-tree is the canonical "seek
--- predicate" form (Markus Winand, use-the-index-luke.com/no-offset).
--- Backed by `idx_bill_keyset(effective_date DESC, id DESC)` from
--- migration 0003 so the optimizer serves this as a single range scan.
+-- Keyset / cursor pagination. Sort key: (effective_date DESC, id DESC, is_credit DESC).
 --
--- The earlier UNION is gone — it was duplicating every bill that had a
--- credit_note row and silently emitting two ids per row. A LEFT JOIN
--- gives the same result (cn.state when present, NULL otherwise) without
--- the duplicate.
+-- Why three keys, not two: a bill that has a credit_note is shown as
+-- TWO list items — the original invoice and its credit note are
+-- different documents in the user's view. The UNION ALL below emits
+-- both with identical (effective_date, id) but different `is_credit`,
+-- so we need that third column as a deterministic tiebreaker for the
+-- seek predicate.
+--
+-- The (cursor_date, cursor_id, cursor_is_credit) sentinels are all
+-- NULL on the first page and all non-NULL on subsequent pages. The
+-- OR-tree is the canonical lex-compare seek predicate
+-- (Markus Winand, use-the-index-luke.com/no-offset).
 --
 -- Caller fetches `limit + 1` to detect has_more without a COUNT(*).
 SELECT bill.id AS id,
-       effective_date,
+       bill.effective_date AS effective_date,
        payment_due_date,
        bill.state AS state,
        discount,
@@ -27,18 +29,44 @@ SELECT bill.id AS id,
        cn.state AS credit_state,
        total,
        total_vat,
-       total_before_vat
+       total_before_vat,
+       1 AS is_credit
 FROM bill
-LEFT JOIN client ON client.id = bill.client_id
-LEFT JOIN credit_note cn ON cn.bill_id = bill.id
+JOIN credit_note cn ON cn.bill_id = bill.id
+LEFT JOIN client  ON client.id = bill.client_id
 WHERE bill.state >= 0
   AND (sqlc.narg('phonenumber') IS NULL OR bill.user_phone_number LIKE sqlc.narg('phonenumber'))
   AND (
         sqlc.narg('cursor_date') IS NULL
      OR bill.effective_date < sqlc.narg('cursor_date')
      OR (bill.effective_date = sqlc.narg('cursor_date') AND bill.id < sqlc.narg('cursor_id'))
+     OR (bill.effective_date = sqlc.narg('cursor_date') AND bill.id = sqlc.narg('cursor_id') AND 1 < sqlc.narg('cursor_is_credit'))
   )
-ORDER BY bill.effective_date DESC, bill.id DESC
+UNION ALL
+SELECT bill.id AS id,
+       bill.effective_date AS effective_date,
+       payment_due_date,
+       bill.state AS state,
+       discount,
+       sequence_number,
+       bill.user_phone_number,
+       client.id IS NOT NULL AS bill_type,
+       0 AS credit_state,
+       total,
+       total_vat,
+       total_before_vat,
+       0 AS is_credit
+FROM bill
+LEFT JOIN client ON client.id = bill.client_id
+WHERE bill.state >= 0
+  AND (sqlc.narg('phonenumber') IS NULL OR bill.user_phone_number LIKE sqlc.narg('phonenumber'))
+  AND (
+        sqlc.narg('cursor_date') IS NULL
+     OR bill.effective_date < sqlc.narg('cursor_date')
+     OR (bill.effective_date = sqlc.narg('cursor_date') AND bill.id < sqlc.narg('cursor_id'))
+     OR (bill.effective_date = sqlc.narg('cursor_date') AND bill.id = sqlc.narg('cursor_id') AND 0 < sqlc.narg('cursor_is_credit'))
+  )
+ORDER BY effective_date DESC, id DESC, is_credit DESC
 LIMIT ?;
 
 

--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -3,19 +3,43 @@
   values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- name: GetAllBill :many
-SELECT * from(
-			SELECT bill.id as id, effective_date, payment_due_date, bill.state as state, discount, sequence_number, bill.user_phone_number, client.id is not null as bill_type, cn.state as credit_state, total, total_vat, total_before_vat
-			FROM bill
-			JOIN credit_note  cn on cn.bill_id = bill.id
-			LEFT JOIN client  on client.id = bill.client_id
-			WHERE bill.state >= 0
-			and (sqlc.narg('phonenumber') is null or bill.user_phone_number like sqlc.narg('phonenumber'))
-			UNION
-			SELECT bill.id as id, effective_date, payment_due_date, bill.state as state, discount, sequence_number, user_phone_number, client.id is not null as bill_type, 0 as credit_state, total, total_vat, total_before_vat from bill
-			LEFT JOIN client  on client.id = bill.client_id
-			WHERE bill. state >= 0
-			and (sqlc.narg('phonenumber') is null or bill.user_phone_number like sqlc.narg('phonenumber'))
-		) AS T ORDER BY id DESC LIMIT ? OFFSET ?;
+-- Keyset / cursor pagination. Sort key: (effective_date DESC, id DESC).
+-- The (cursor_date, cursor_id) sentinels are NULL on the first page and
+-- non-NULL on subsequent pages; the OR-tree is the canonical "seek
+-- predicate" form (Markus Winand, use-the-index-luke.com/no-offset).
+-- Backed by `idx_bill_keyset(effective_date DESC, id DESC)` from
+-- migration 0003 so the optimizer serves this as a single range scan.
+--
+-- The earlier UNION is gone — it was duplicating every bill that had a
+-- credit_note row and silently emitting two ids per row. A LEFT JOIN
+-- gives the same result (cn.state when present, NULL otherwise) without
+-- the duplicate.
+--
+-- Caller fetches `limit + 1` to detect has_more without a COUNT(*).
+SELECT bill.id AS id,
+       effective_date,
+       payment_due_date,
+       bill.state AS state,
+       discount,
+       sequence_number,
+       bill.user_phone_number,
+       client.id IS NOT NULL AS bill_type,
+       cn.state AS credit_state,
+       total,
+       total_vat,
+       total_before_vat
+FROM bill
+LEFT JOIN client ON client.id = bill.client_id
+LEFT JOIN credit_note cn ON cn.bill_id = bill.id
+WHERE bill.state >= 0
+  AND (sqlc.narg('phonenumber') IS NULL OR bill.user_phone_number LIKE sqlc.narg('phonenumber'))
+  AND (
+        sqlc.narg('cursor_date') IS NULL
+     OR bill.effective_date < sqlc.narg('cursor_date')
+     OR (bill.effective_date = sqlc.narg('cursor_date') AND bill.id < sqlc.narg('cursor_id'))
+  )
+ORDER BY bill.effective_date DESC, bill.id DESC
+LIMIT ?;
 
 
 -- name: GetBillByID :one

--- a/pkg/db/queries/client.sql
+++ b/pkg/db/queries/client.sql
@@ -1,5 +1,16 @@
 -- name: GetClients :many
-SELECT * FROM client where is_deleted = FALSE ORDER BY updated_at  DESC LIMIT ? OFFSET ?;
+-- Keyset pagination on (updated_at DESC, id DESC). Backed by
+-- idx_client_keyset (migration 0003). Sort key carries updated_at so
+-- the FE keeps the existing "recently-touched first" UX.
+SELECT * FROM client
+WHERE is_deleted = FALSE
+  AND (
+        sqlc.narg('cursor_updated_at') IS NULL
+     OR updated_at < sqlc.narg('cursor_updated_at')
+     OR (updated_at = sqlc.narg('cursor_updated_at') AND id < sqlc.narg('cursor_id'))
+  )
+ORDER BY updated_at DESC, id DESC
+LIMIT ?;
 
 -- name: GetClientByID :one
 SELECT * FROM client WHERE id = ? and is_deleted = FALSE LIMIT 1;

--- a/pkg/db/queries/product.sql
+++ b/pkg/db/queries/product.sql
@@ -2,12 +2,17 @@
 select p.* from product p where p.id = ? and is_deleted = False;
 
 -- name: GetAllProduct :many
+-- Keyset pagination on (id DESC). The InnoDB primary key already
+-- serves the scan order natively — no extra index needed. Caller
+-- fetches limit+1 to detect has_more.
 select p.*
 from user
 join store s on s.company_id = user.company_id
 join product p on p.store_id = s.id
 where user.id = ? and is_deleted = False
-ORDER BY p.id DESC LIMIT ? OFFSET ?;
+  and (sqlc.narg('cursor_id') is null or p.id < sqlc.narg('cursor_id'))
+ORDER BY p.id DESC
+LIMIT ?;
 
 -- name: AddProduct :execresult
 INSERT INTO product (article_id, quantity, price, cost_price ,shelf_number, store_id, name) VALUES (?,?,?,?,?,?,?)

--- a/pkg/db/queries/purchase_bill.sql
+++ b/pkg/db/queries/purchase_bill.sql
@@ -1,11 +1,21 @@
 -- name: GetAllPurchaseBill :many
+-- Keyset pagination on (effective_date DESC, id DESC). Backed by
+-- idx_pb_keyset (migration 0003) so the seek runs as a single index
+-- range scan with no filesort. Caller fetches limit+1 to detect
+-- has_more without a COUNT.
 select b.*
 	from purchase_bill as b
 	join store on store.id = b.store_id
 	join company on company.id = store.company_id
-	join user on user.id= ? and company.id=user.company_id
+	join user on user.id = ? and company.id = user.company_id
 	where b.state >= 0
-	order by id desc limit ? offset ?;
+	  and (
+	        sqlc.narg('cursor_date') is null
+	     or b.effective_date < sqlc.narg('cursor_date')
+	     or (b.effective_date = sqlc.narg('cursor_date') and b.id < sqlc.narg('cursor_id'))
+	  )
+	order by b.effective_date desc, b.id desc
+	limit ?;
 
 -- name: GetPurchaseBillDetail :one
 select b.*

--- a/pkg/db/queries/supplier.sql
+++ b/pkg/db/queries/supplier.sql
@@ -5,7 +5,12 @@ UPDATE supplier SET name=?, address=?, phone_number=?, number=?, vat_number=?, b
 SELECT * From supplier where is_deleted = FALSE and id = ?;
 
 -- name: GetAllSupplier :many
-SELECT * From supplier where is_deleted = FALSE order by id desc limit ? offset ?;
+-- Keyset pagination on (id DESC). Primary key serves the scan order.
+SELECT * From supplier
+WHERE is_deleted = FALSE
+  AND (sqlc.narg('cursor_id') IS NULL OR id < sqlc.narg('cursor_id'))
+ORDER BY id DESC
+LIMIT ?;
 
 -- name: AddSupplier :execresult
 INSERT INTO supplier (company_id, name, address, phone_number, number, vat_number, bank_account, is_postpaid, credit_limit, payment_terms_days, preferred_payment_method, commercial_registration, short_address, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -114,13 +114,18 @@ func (h *handler) GetBills(c *gin.Context) {
 		phoneFilter = &s
 	}
 
-	// Decode cursor into the (cursor_date, cursor_id) pair the SQL
-	// expects. Both nil on the first page; both set on subsequent
-	// pages. We keep them paired — a half-decoded cursor is a 400.
+	// Decode cursor into the (cursor_date, cursor_id, cursor_is_credit)
+	// triple the SQL expects. All nil on the first page; all set on
+	// subsequent pages. We keep them paired — a half-decoded cursor is
+	// a 400. The third key (`is_credit`) is needed because a bill with
+	// a credit_note appears as two distinct rows sharing the same
+	// (effective_date, id); without it the seek would skip or duplicate
+	// the second row.
 	cur, _ := listReq.DecodedCursor()
 	var cursorDate *time.Time
 	var cursorID *uint64
-	if len(cur.K) >= 2 {
+	var cursorIsCredit any
+	if len(cur.K) >= 3 {
 		if dStr, ok := cur.K[0].(string); ok {
 			if t, err := time.Parse(time.RFC3339Nano, dStr); err == nil {
 				cursorDate = &t
@@ -128,12 +133,44 @@ func (h *handler) GetBills(c *gin.Context) {
 				cursorDate = &t
 			}
 		}
-		if id, ok := cur.LastID(); ok && id > 0 {
-			u := uint64(id)
-			cursorID = &u
+		if idAny := cur.K[1]; idAny != nil {
+			switch v := idAny.(type) {
+			case float64:
+				if v > 0 {
+					u := uint64(v)
+					cursorID = &u
+				}
+			case int64:
+				if v > 0 {
+					u := uint64(v)
+					cursorID = &u
+				}
+			default:
+				// json.Number path
+				if n, ok := idAny.(interface{ Int64() (int64, error) }); ok {
+					if i, err := n.Int64(); err == nil && i > 0 {
+						u := uint64(i)
+						cursorID = &u
+					}
+				}
+			}
 		}
-		if cursorDate == nil || cursorID == nil {
-			log.Printf("GetBills: cursor missing date or id")
+		if icAny := cur.K[2]; icAny != nil {
+			switch v := icAny.(type) {
+			case float64:
+				cursorIsCredit = int32(v)
+			case int64:
+				cursorIsCredit = int32(v)
+			default:
+				if n, ok := icAny.(interface{ Int64() (int64, error) }); ok {
+					if i, err := n.Int64(); err == nil {
+						cursorIsCredit = int32(i)
+					}
+				}
+			}
+		}
+		if cursorDate == nil || cursorID == nil || cursorIsCredit == nil {
+			log.Printf("GetBills: cursor missing date, id or is_credit")
 			c.Status(http.StatusBadRequest)
 			return
 		}
@@ -142,9 +179,10 @@ func (h *handler) GetBills(c *gin.Context) {
 	limit := listReq.EffectiveLimit()
 
 	args := db.GetAllBillParams{
-		Phonenumber: phoneFilter,
-		CursorDate:  cursorDate,
-		CursorID:    cursorID,
+		Phonenumber:    phoneFilter,
+		CursorDate:     cursorDate,
+		CursorID:       cursorID,
+		CursorIsCredit: cursorIsCredit,
 		// +1 row signals has_more without a COUNT(*).
 		Limit: int32(limit + 1),
 	}
@@ -159,12 +197,17 @@ func (h *handler) GetBills(c *gin.Context) {
 		bills,
 		limit,
 		billListSort,
-		// Keyset for the next page is (effective_date, id) of the last
-		// kept row. Date is serialized as RFC3339 so the FE round-trips
-		// it as a string and hands it back verbatim — keeps the cursor
-		// timezone-stable across BE/FE.
+		// Keyset for the next page is (effective_date, id, is_credit)
+		// of the last kept row. The is_credit tiebreaker is required
+		// because credit-note variants share the bill's id and date.
+		// Date is RFC3339Nano so the FE round-trips it as a string and
+		// hands it back verbatim — keeps the cursor timezone-stable.
 		func(r db.GetAllBillRow) []any {
-			return []any{r.EffectiveDate.UTC().Format(time.RFC3339Nano), r.ID}
+			return []any{
+				r.EffectiveDate.UTC().Format(time.RFC3339Nano),
+				r.ID,
+				r.IsCredit,
+			}
 		},
 	)
 	c.JSON(http.StatusOK, envelope)

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"math/big"
 	"net/http"
@@ -52,6 +53,10 @@ func effectiveDateOr(ed *time.Time) time.Time {
 	return time.Now()
 }
 
+// billListSort is the canonical sort spec for the bill list. Cursor
+// validation rejects any client-supplied sort that doesn't match this.
+const billListSort = "-effective_date"
+
 func (h *handler) GetBills(c *gin.Context) {
 
 	userSession := GetSessionInfo(c)
@@ -61,10 +66,7 @@ func (h *handler) GetBills(c *gin.Context) {
 		storeIds = append(storeIds, value.Id)
 	}
 
-	request := model.BillRequestFilter{
-		Page:     0,
-		PageSize: 10,
-	}
+	request := model.BillRequestFilter{}
 
 	if err := c.BindJSON(&request); err != nil {
 		log.Printf("GetBills: %v", err)
@@ -72,7 +74,18 @@ func (h *handler) GetBills(c *gin.Context) {
 		return
 	}
 
-	if request.Page < 0 || request.PageSize <= 0 {
+	// Build a ListRequest view to hand to the shared validator. It
+	// shares the same wire keys (limit/cursor/sort/page_size/...).
+	listReq := pagination.ListRequest{
+		Limit:      request.Limit,
+		Cursor:     request.Cursor,
+		Sort:       request.Sort,
+		Query:      request.Query,
+		PageNumber: request.Page,
+		PageSize:   request.PageSize,
+	}
+	if err := listReq.Validate(billListSort); err != nil {
+		log.Printf("GetBills: %v", err)
 		c.Status(http.StatusBadRequest)
 		return
 	}
@@ -84,7 +97,7 @@ func (h *handler) GetBills(c *gin.Context) {
 		request.StoreIds = storeIds
 	}
 	if len(request.StoreIds) == 0 {
-		c.JSON(http.StatusOK, []any{})
+		c.JSON(http.StatusOK, pagination.Envelope[db.GetAllBillRow]{Items: []db.GetAllBillRow{}})
 		return
 	}
 
@@ -95,22 +108,66 @@ func (h *handler) GetBills(c *gin.Context) {
 		}
 	}
 
+	var phoneFilter *string
 	if request.Query != nil {
-		data := "%" + *request.Query + "%"
-		request.Query = &data
+		s := "%" + *request.Query + "%"
+		phoneFilter = &s
 	}
 
+	// Decode cursor into the (cursor_date, cursor_id) pair the SQL
+	// expects. Both nil on the first page; both set on subsequent
+	// pages. We keep them paired — a half-decoded cursor is a 400.
+	cur, _ := listReq.DecodedCursor()
+	var cursorDate *time.Time
+	var cursorID *uint64
+	if len(cur.K) >= 2 {
+		if dStr, ok := cur.K[0].(string); ok {
+			if t, err := time.Parse(time.RFC3339Nano, dStr); err == nil {
+				cursorDate = &t
+			} else if t, err := time.Parse(time.RFC3339, dStr); err == nil {
+				cursorDate = &t
+			}
+		}
+		if id, ok := cur.LastID(); ok && id > 0 {
+			u := uint64(id)
+			cursorID = &u
+		}
+		if cursorDate == nil || cursorID == nil {
+			log.Printf("GetBills: cursor missing date or id")
+			c.Status(http.StatusBadRequest)
+			return
+		}
+	}
+
+	limit := listReq.EffectiveLimit()
+
 	args := db.GetAllBillParams{
-		Phonenumber: request.Query,
-		Limit:       int32(request.PageSize),
-		Offset:      int32(request.Page) * int32(request.PageSize),
+		Phonenumber: phoneFilter,
+		CursorDate:  cursorDate,
+		CursorID:    cursorID,
+		// +1 row signals has_more without a COUNT(*).
+		Limit: int32(limit + 1),
 	}
 	bills, err := h.queries.GetAllBill(c.Request.Context(), args)
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		log.Printf("GetBills: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
-	c.JSON(http.StatusOK, bills)
+
+	envelope := pagination.BuildEnvelope(
+		bills,
+		limit,
+		billListSort,
+		// Keyset for the next page is (effective_date, id) of the last
+		// kept row. Date is serialized as RFC3339 so the FE round-trips
+		// it as a string and hands it back verbatim — keeps the cursor
+		// timezone-stable across BE/FE.
+		func(r db.GetAllBillRow) []any {
+			return []any{r.EffectiveDate.UTC().Format(time.RFC3339Nano), r.ID}
+		},
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 func (h *handler) AddBill(c *gin.Context) {

--- a/pkg/handlers/branch.go
+++ b/pkg/handlers/branch.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	db "ifritah/web-service-gin/pkg/db/gen"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"net/http"
 	"strconv"
@@ -21,10 +22,50 @@ type OTPRequest struct {
 	OTP string `json:"otp" binding:"required"`
 }
 
+const branchListSort = "id"
+
 // ── POST /api/v2/branch/all ─────────────────────────────────────────────────
-// Returns all branches with store count and ZATCA registration status.
+// Cursor-paginated list of branches with store count and ZATCA
+// registration status. Sort key: id ASC (matches the pre-cursor ORDER
+// BY b.id ascending). Primary key serves the seek directly.
 
 func (h *handler) ListBranches(c *gin.Context) {
+	var req struct {
+		Limit  int    `json:"limit"`
+		Cursor string `json:"cursor"`
+		Sort   string `json:"sort"`
+		// Legacy keys ignored once Cursor != "".
+		PageNumber int `json:"page_number"`
+		PageSize   int `json:"page_size"`
+	}
+	c.ShouldBindJSON(&req)
+
+	listReq := pagination.ListRequest{
+		Limit:      req.Limit,
+		Cursor:     req.Cursor,
+		Sort:       req.Sort,
+		PageNumber: req.PageNumber,
+		PageSize:   req.PageSize,
+	}
+	if err := listReq.Validate(branchListSort); err != nil {
+		log.Printf("ListBranches: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	cur, _ := listReq.DecodedCursor()
+	cursorID := cursorIDOnly(cur)
+
+	limit := listReq.EffectiveLimit()
+
+	where := ""
+	args := []any{}
+	if cursorID != nil {
+		where = "WHERE b.id > ?"
+		args = append(args, *cursorID)
+	}
+	args = append(args, limit+1)
+
 	rows, err := h.DB.Query(`
 		SELECT b.id, b.name, COALESCE(b.address,''), COALESCE(b.city,''),
 		       COALESCE(b.phone,''), b.company_id, b.manager_id, b.is_active,
@@ -37,8 +78,10 @@ func (h *handler) ListBranches(c *gin.Context) {
 		       END) AS zatca_status
 		FROM branches b
 		LEFT JOIN branch_zatca_config bzc ON bzc.branch_id = b.id
+		`+where+`
 		ORDER BY b.id
-	`)
+		LIMIT ?
+	`, args...)
 	if err != nil {
 		log.Printf("ERROR ListBranches: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"detail": "failed to fetch branches"})
@@ -72,10 +115,13 @@ func (h *handler) ListBranches(c *gin.Context) {
 		branches = append(branches, b)
 	}
 
-	if branches == nil {
-		branches = []branchRow{}
-	}
-	c.JSON(http.StatusOK, gin.H{"data": branches})
+	envelope := pagination.BuildEnvelope(
+		branches,
+		limit,
+		branchListSort,
+		func(b branchRow) []any { return []any{int64(b.ID)} },
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 // ── GET /api/v2/branch/:id ──────────────────────────────────────────────────

--- a/pkg/handlers/cash_vouchar.go
+++ b/pkg/handlers/cash_vouchar.go
@@ -3,8 +3,8 @@ package handlers
 import (
 	"database/sql"
 	db "ifritah/web-service-gin/pkg/db/gen"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
-	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -40,8 +40,14 @@ import (
 // --- Request / Response types (local to this file) ---
 
 type cashVoucherListRequest struct {
-	PageNumber  int    `json:"page_number"`
-	PageSize    int    `json:"page_size"`
+	// New cursor pagination keys.
+	Limit  int    `json:"limit"`
+	Cursor string `json:"cursor"`
+	Sort   string `json:"sort"`
+	// Legacy keys — accepted for backwards compat, ignored once Cursor != "".
+	PageNumber int `json:"page_number"`
+	PageSize   int `json:"page_size"`
+
 	Query       string `json:"query"`
 	VoucherType string `json:"voucher_type"` // "disbursement", "receipt", or "" for all
 }
@@ -115,31 +121,45 @@ type cashVoucherDetail struct {
 
 // ── List ────────────────────────────────────────────────────────────────────
 
-// ListCashVouchers returns paginated cash vouchers for the merchant.
+const cashVoucherListSort = "-effective_date"
+
+// ListCashVouchers returns a cursor-paginated page of cash vouchers
+// scoped to the calling merchant. Sort key: (effective_date DESC, id
+// DESC), backed by idx_cv_keyset (migration 0003).
 // POST /api/v2/cash_voucher/all
 func (h *handler) ListCashVouchers(c *gin.Context) {
 	var req cashVoucherListRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
-		// Allow empty body — defaults will be used
 		req = cashVoucherListRequest{}
 	}
 
-	// Defaults
-	if req.PageSize <= 0 {
-		req.PageSize = 10
+	listReq := pagination.ListRequest{
+		Limit:      req.Limit,
+		Cursor:     req.Cursor,
+		Sort:       req.Sort,
+		PageNumber: req.PageNumber,
+		PageSize:   req.PageSize,
 	}
-	if req.PageSize > 100 {
-		req.PageSize = 100
+	if err := listReq.Validate(cashVoucherListSort); err != nil {
+		log.Printf("ListCashVouchers: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
 	}
 
+	cur, _ := listReq.DecodedCursor()
+	cursorDate, cursorID, ok := cursorDateAndID(cur)
+	if !ok {
+		log.Printf("ListCashVouchers: malformed cursor")
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	limit := listReq.EffectiveLimit()
 	merchantID := getMerchantID(c)
-	offset := req.PageNumber * req.PageSize
 
-	// Build WHERE clause dynamically
 	where := "WHERE merchant_id = ?"
-	args := []interface{}{merchantID}
+	args := []any{merchantID}
 
-	// Filter by voucher_type
 	if req.VoucherType != "" {
 		if req.VoucherType != "disbursement" && req.VoucherType != "receipt" && req.VoucherType != "cash_box" {
 			c.JSON(http.StatusBadRequest, gin.H{"detail": "نوع السند غير صالح"})
@@ -149,23 +169,21 @@ func (h *handler) ListCashVouchers(c *gin.Context) {
 		args = append(args, req.VoucherType)
 	}
 
-	// Search query
 	if req.Query != "" {
 		where += " AND (recipient_name LIKE ? OR description LIKE ? OR note LIKE ?)"
 		q := "%" + req.Query + "%"
 		args = append(args, q, q, q)
 	}
 
-	// Count total for pagination
-	var total int
-	countSQL := "SELECT COUNT(*) FROM cash_voucher " + where
-	if err := h.DB.QueryRow(countSQL, args...).Scan(&total); err != nil {
-		log.Printf("ERROR ListCashVouchers count: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"detail": "خطأ في قراءة البيانات"})
-		return
+	// Seek predicate (skip on first page).
+	if cursorDate != nil && cursorID != nil {
+		where += " AND (effective_date < ? OR (effective_date = ? AND id < ?))"
+		args = append(args, *cursorDate, *cursorDate, *cursorID)
 	}
 
-	// Query page
+	// +1 row trick for has_more.
+	args = append(args, limit+1)
+
 	dataSQL := `
 		SELECT id, voucher_number, voucher_type, effective_date, amount,
 		       payment_method, state, reference_type, reference_id,
@@ -173,9 +191,8 @@ func (h *handler) ListCashVouchers(c *gin.Context) {
 		       description, store_id, merchant_id, created_by, created_at
 		FROM cash_voucher ` + where + `
 		ORDER BY effective_date DESC, id DESC
-		LIMIT ? OFFSET ?
+		LIMIT ?
 	`
-	args = append(args, req.PageSize, offset)
 
 	rows, err := h.DB.Query(dataSQL, args...)
 	if err != nil {
@@ -201,15 +218,15 @@ func (h *handler) ListCashVouchers(c *gin.Context) {
 		items = append(items, v)
 	}
 
-	totalPages := int(math.Ceil(float64(total) / float64(req.PageSize)))
-
-	c.JSON(http.StatusOK, gin.H{
-		"data":        items,
-		"total":       total,
-		"total_pages": totalPages,
-		"page":        req.PageNumber,
-		"page_size":   req.PageSize,
-	})
+	envelope := pagination.BuildEnvelope(
+		items,
+		limit,
+		cashVoucherListSort,
+		func(v cashVoucherListItem) []any {
+			return []any{v.EffectiveDate.UTC().Format(time.RFC3339Nano), int64(v.ID)}
+		},
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 // ── Detail ──────────────────────────────────────────────────────────────────

--- a/pkg/handlers/client.go
+++ b/pkg/handlers/client.go
@@ -5,8 +5,11 @@ import (
 	"fmt"
 	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
+	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-sql-driver/mysql"
@@ -33,23 +36,60 @@ func (h *handler) GetClient(c *gin.Context) {
 
 }
 
+const clientListSort = "-updated_at"
+
 func (h *handler) GetAllClient(c *gin.Context) {
-	request := model.PaginationRequest{
-		Page:     0,
-		PageSize: 10,
-	}
+	request := model.PaginationRequest{}
 
 	if err := c.BindJSON(&request); err != nil {
+		log.Printf("GetAllClient: %v", err)
+		c.Status(http.StatusBadRequest)
 		return
 	}
-	res, err := h.queries.GetClients(c.Request.Context(), db.GetClientsParams{Limit: request.PageSize, Offset: request.Page * request.PageSize})
+
+	listReq := listRequestFromPagination(request)
+	if err := listReq.Validate(clientListSort); err != nil {
+		log.Printf("GetAllClient: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	cur, _ := listReq.DecodedCursor()
+	cursorUpdatedAt, cursorID, ok := cursorDateAndID(cur)
+	if !ok {
+		log.Printf("GetAllClient: malformed cursor")
+		c.Status(http.StatusBadRequest)
+		return
+	}
+	// Cursor uses uint32 PK in the gen for client.
+	var cursorIDU32 *uint32
+	if cursorID != nil {
+		v := uint32(*cursorID)
+		cursorIDU32 = &v
+	}
+
+	limit := listReq.EffectiveLimit()
+
+	res, err := h.queries.GetClients(c.Request.Context(), db.GetClientsParams{
+		CursorUpdatedAt: cursorUpdatedAt,
+		CursorID:        cursorIDU32,
+		Limit:           int32(limit + 1),
+	})
 	if err != nil {
+		log.Printf("GetAllClient: %v", err)
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 
-	c.JSON(http.StatusOK, res)
-
+	envelope := pagination.BuildEnvelope(
+		res,
+		limit,
+		clientListSort,
+		func(cl db.Client) []any {
+			return []any{cl.UpdatedAt.UTC().Format(time.RFC3339Nano), cl.ID}
+		},
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 type CreateClientRequest struct {

--- a/pkg/handlers/list_helpers.go
+++ b/pkg/handlers/list_helpers.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
+	"time"
+)
+
+// listRequestFromPagination adapts the existing model.PaginationRequest
+// into the shared pagination.ListRequest. Used by handlers that don't
+// need extra resource-specific filters (client/supplier/product etc.).
+func listRequestFromPagination(p model.PaginationRequest) pagination.ListRequest {
+	page := p.Page
+	if page == 0 {
+		page = p.PageNumber
+	}
+	return pagination.ListRequest{
+		Limit:      int(p.Limit),
+		Cursor:     p.Cursor,
+		Sort:       p.Sort,
+		Query:      p.Query,
+		PageNumber: int(page),
+		PageSize:   int(p.PageSize),
+	}
+}
+
+// cursorIDOnly decodes the trailing id from a cursor for resources
+// whose sort key is just `id DESC`. Returns nil when the cursor is
+// empty (first page) or when the id cannot be parsed.
+func cursorIDOnly(c pagination.Cursor) *uint64 {
+	if len(c.K) == 0 {
+		return nil
+	}
+	id, ok := c.LastID()
+	if !ok || id <= 0 {
+		return nil
+	}
+	u := uint64(id)
+	return &u
+}
+
+// cursorDateAndID decodes a (date, id) keyset cursor. Returns (nil,nil)
+// for first-page cursors and (nonnil, nonnil) for subsequent pages.
+// Returns (nil, nil, false) when the cursor is malformed and the caller
+// should respond 400.
+func cursorDateAndID(c pagination.Cursor) (*time.Time, *uint64, bool) {
+	if len(c.K) == 0 {
+		return nil, nil, true
+	}
+	if len(c.K) < 2 {
+		return nil, nil, false
+	}
+	var t *time.Time
+	if dStr, ok := c.K[0].(string); ok {
+		if parsed, err := time.Parse(time.RFC3339Nano, dStr); err == nil {
+			t = &parsed
+		} else if parsed, err := time.Parse(time.RFC3339, dStr); err == nil {
+			t = &parsed
+		}
+	}
+	id, ok := c.LastID()
+	if t == nil || !ok || id <= 0 {
+		return nil, nil, false
+	}
+	u := uint64(id)
+	return t, &u, true
+}

--- a/pkg/handlers/order.go
+++ b/pkg/handlers/order.go
@@ -40,39 +40,63 @@ package handlers
 import (
 	"database/sql"
 	"fmt"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
+const orderListSort = "-created_at"
+
 // ── POST /api/v2/order/all ──────────────────────────────────────────────────
-// Lists orders with optional pagination and search.
-// Request body (JSON):
-//   { "page_number": 1, "page_size": 20, "query": "ORD" }
-// All fields optional. Defaults: page 1, size 20, no filter.
+// Cursor-paginated list of orders for the calling user's company. The
+// seek key is (created_at DESC, id DESC), backed by idx_orders_keyset
+// (migration 0003) so the optimizer serves it as a single range scan.
 
 func (h *handler) GetOrders(c *gin.Context) {
 	companyID := h.getUserCompany(c)
 
 	var req struct {
-		PageNumber int    `json:"page_number"`
-		PageSize   int    `json:"page_size"`
-		Query      string `json:"query"`
+		// New cursor-pagination keys.
+		Limit  int    `json:"limit"`
+		Cursor string `json:"cursor"`
+		Sort   string `json:"sort"`
+		Query  string `json:"query"`
+		// Legacy offset keys — accepted but ignored once Cursor != "".
+		PageNumber int `json:"page_number"`
+		PageSize   int `json:"page_size"`
 	}
 	c.ShouldBindJSON(&req)
-	if req.PageNumber < 1 {
-		req.PageNumber = 1
+
+	listReq := pagination.ListRequest{
+		Limit:      req.Limit,
+		Cursor:     req.Cursor,
+		Sort:       req.Sort,
+		PageNumber: req.PageNumber,
+		PageSize:   req.PageSize,
 	}
-	if req.PageSize < 1 || req.PageSize > 10000 {
-		req.PageSize = 20
+	if err := listReq.Validate(orderListSort); err != nil {
+		log.Printf("GetOrders: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
 	}
 
-	// Build WHERE clause
+	cur, _ := listReq.DecodedCursor()
+	cursorCreatedAt, cursorID, ok := cursorDateAndID(cur)
+	if !ok {
+		log.Printf("GetOrders: malformed cursor")
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	limit := listReq.EffectiveLimit()
+
 	where := "WHERE o.store_id IN (SELECT id FROM store WHERE company_id = ?)"
-	args := []interface{}{companyID}
+	args := []any{companyID}
 
 	if req.Query != "" {
 		where += " AND (o.sequence_number LIKE ? OR o.customer_name LIKE ?)"
@@ -80,25 +104,26 @@ func (h *handler) GetOrders(c *gin.Context) {
 		args = append(args, like, like)
 	}
 
-	// Count total
-	var total int
-	h.DB.QueryRow("SELECT COUNT(*) FROM orders o "+where, args...).Scan(&total)
+	// Seek predicate (canonical OR-tree form). Skip when no cursor —
+	// that's the first page.
+	if cursorCreatedAt != nil && cursorID != nil {
+		where += " AND (o.created_at < ? OR (o.created_at = ? AND o.id < ?))"
+		args = append(args, *cursorCreatedAt, *cursorCreatedAt, *cursorID)
+	}
 
-	// Paginate
-	offset := (req.PageNumber - 1) * req.PageSize
-	args = append(args, req.PageSize, offset)
+	// +1 row trick.
+	args = append(args, limit+1)
 
 	rows, err := h.DB.Query(`
 		SELECT o.id, o.sequence_number, o.client_id, COALESCE(o.customer_name,''),
 		       o.store_id, o.status, o.total, COALESCE(o.note,''),
-		       o.created_by, DATE_FORMAT(o.created_at, '%Y-%m-%dT%H:%i:%s') AS created_at,
-		       DATE_FORMAT(o.updated_at, '%Y-%m-%dT%H:%i:%s') AS updated_at,
+		       o.created_by, o.created_at, o.updated_at,
 		       COALESCE(c.name, o.customer_name, '') AS client_name
 		FROM orders o
 		LEFT JOIN client c ON c.id = o.client_id
 		`+where+`
 		ORDER BY o.created_at DESC, o.id DESC
-		LIMIT ? OFFSET ?
+		LIMIT ?
 	`, args...)
 	if err != nil {
 		log.Printf("ERROR GetOrders: %v", err)
@@ -108,18 +133,18 @@ func (h *handler) GetOrders(c *gin.Context) {
 	defer rows.Close()
 
 	type orderRow struct {
-		ID             int     `json:"id"`
-		SequenceNumber string  `json:"sequence_number"`
-		ClientID       *int    `json:"client_id"`
-		CustomerName   string  `json:"customer_name"`
-		StoreID        *int    `json:"store_id"`
-		Status         string  `json:"status"`
-		Total          float64 `json:"total"`
-		Note           string  `json:"note"`
-		CreatedBy      int     `json:"created_by"`
-		CreatedAt      string  `json:"created_at"`
-		UpdatedAt      string  `json:"updated_at"`
-		ClientName     string  `json:"client_name"`
+		ID             int       `json:"id"`
+		SequenceNumber string    `json:"sequence_number"`
+		ClientID       *int      `json:"client_id"`
+		CustomerName   string    `json:"customer_name"`
+		StoreID        *int      `json:"store_id"`
+		Status         string    `json:"status"`
+		Total          float64   `json:"total"`
+		Note           string    `json:"note"`
+		CreatedBy      int       `json:"created_by"`
+		CreatedAt      time.Time `json:"created_at"`
+		UpdatedAt      time.Time `json:"updated_at"`
+		ClientName     string    `json:"client_name"`
 	}
 
 	var orders []orderRow
@@ -137,18 +162,15 @@ func (h *handler) GetOrders(c *gin.Context) {
 		orders = []orderRow{}
 	}
 
-	totalPages := total / req.PageSize
-	if total%req.PageSize > 0 {
-		totalPages++
-	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"data":        orders,
-		"total":       total,
-		"page":        req.PageNumber,
-		"page_size":   req.PageSize,
-		"total_pages": totalPages,
-	})
+	envelope := pagination.BuildEnvelope(
+		orders,
+		limit,
+		orderListSort,
+		func(o orderRow) []any {
+			return []any{o.CreatedAt.UTC().Format(time.RFC3339Nano), int64(o.ID)}
+		},
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 // ── GET /api/v2/order/:id ───────────────────────────────────────────────────

--- a/pkg/handlers/product.go
+++ b/pkg/handlers/product.go
@@ -3,12 +3,14 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"slices"
 	"strconv"
 
 	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
 
 	"github.com/gin-gonic/gin"
 	"github.com/go-sql-driver/mysql"
@@ -110,31 +112,50 @@ func (h *handler) UpdateProduct(c *gin.Context) {
 
 }
 
+const productListSort = "-id"
+
 func (h *handler) GetAllProducts(c *gin.Context) {
 	user := GetSessionInfo(c)
 
-	request := model.PaginationRequest{
-		Page:     0,
-		PageSize: 10,
-	}
+	request := model.PaginationRequest{}
 
 	if err := c.BindJSON(&request); err != nil {
+		log.Printf("GetAllProducts: %v", err)
+		c.Status(http.StatusBadRequest)
 		return
 	}
 
+	listReq := listRequestFromPagination(request)
+	if err := listReq.Validate(productListSort); err != nil {
+		log.Printf("GetAllProducts: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	cur, _ := listReq.DecodedCursor()
+	cursorID := cursorIDOnly(cur)
+	limit := listReq.EffectiveLimit()
+
 	args := db.GetAllProductParams{
-		ID:     int32(user.id),
-		Limit:  request.PageSize,
-		Offset: request.PageSize * request.Page,
+		ID:       int32(user.id),
+		CursorID: cursorID,
+		Limit:    int32(limit + 1),
 	}
 
 	products, err := h.queries.GetAllProduct(c.Request.Context(), args)
 	if err != nil {
+		log.Printf("GetAllProducts: %v", err)
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, products)
+	envelope := pagination.BuildEnvelope(
+		products,
+		limit,
+		productListSort,
+		func(p db.Product) []any { return []any{p.ID} },
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 func (h *handler) DeleteProduct(c *gin.Context) {

--- a/pkg/handlers/purchase_bill.go
+++ b/pkg/handlers/purchase_bill.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"net/http"
 	"slices"
@@ -18,13 +19,7 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func (h *handler) getPurchaseBills(c *gin.Context, page int32, pageSize int32, userID int32) []db.PurchaseBill {
-
-	args := db.GetAllPurchaseBillParams{
-		ID:     userID,
-		Limit:  pageSize,
-		Offset: pageSize * page,
-	}
+func (h *handler) getPurchaseBills(c *gin.Context, args db.GetAllPurchaseBillParams) []db.PurchaseBill {
 
 	bills, err := h.queries.GetAllPurchaseBill(c.Request.Context(), args)
 
@@ -328,6 +323,8 @@ func addProductToBillPurchase(tx *db.Queries, c *gin.Context, products []model.P
 	return nil
 }
 
+const purchaseBillListSort = "-effective_date"
+
 func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 
 	userSession := GetSessionInfo(c)
@@ -337,10 +334,7 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 		storeIds = append(storeIds, value.Id)
 	}
 
-	request := model.BillRequestFilter{
-		Page:     0,
-		PageSize: 10,
-	}
+	request := model.BillRequestFilter{}
 
 	if err := c.BindJSON(&request); err != nil {
 		log.Printf("GetAllPurchaseBill: %v", err)
@@ -348,19 +342,25 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 		return
 	}
 
-	if request.Page < 0 || request.PageSize <= 0 {
+	listReq := pagination.ListRequest{
+		Limit:      request.Limit,
+		Cursor:     request.Cursor,
+		Sort:       request.Sort,
+		Query:      request.Query,
+		PageNumber: request.Page,
+		PageSize:   request.PageSize,
+	}
+	if err := listReq.Validate(purchaseBillListSort); err != nil {
+		log.Printf("GetAllPurchaseBill: %v", err)
 		c.Status(http.StatusBadRequest)
 		return
 	}
 
-	// store_ids is a filter, not a primary key. When omitted, default to
-	// every store the caller can access. Truly no accessible stores means
-	// "empty result", not "bad request".
 	if len(request.StoreIds) == 0 {
 		request.StoreIds = storeIds
 	}
 	if len(request.StoreIds) == 0 {
-		c.JSON(http.StatusOK, []any{})
+		c.JSON(http.StatusOK, pagination.Envelope[db.PurchaseBill]{Items: []db.PurchaseBill{}})
 		return
 	}
 
@@ -371,9 +371,32 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 		}
 	}
 
-	bill := h.getPurchaseBills(c, int32(request.Page), int32(request.PageSize), int32(userSession.id))
+	cur, _ := listReq.DecodedCursor()
+	cursorDate, cursorID, ok := cursorDateAndID(cur)
+	if !ok {
+		log.Printf("GetAllPurchaseBill: malformed cursor")
+		c.Status(http.StatusBadRequest)
+		return
+	}
 
-	c.JSON(http.StatusOK, bill)
+	limit := listReq.EffectiveLimit()
+
+	bill := h.getPurchaseBills(c, db.GetAllPurchaseBillParams{
+		ID:         int32(userSession.id),
+		CursorDate: cursorDate,
+		CursorID:   cursorID,
+		Limit:      int32(limit + 1),
+	})
+
+	envelope := pagination.BuildEnvelope(
+		bill,
+		limit,
+		purchaseBillListSort,
+		func(b db.PurchaseBill) []any {
+			return []any{b.EffectiveDate.UTC().Format(time.RFC3339Nano), b.ID}
+		},
+	)
+	c.JSON(http.StatusOK, envelope)
 }
 
 func (h *handler) GetPurchaseBillDetail(c *gin.Context) {

--- a/pkg/handlers/store.go
+++ b/pkg/handlers/store.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"net/http"
 	"strconv"
@@ -62,8 +63,17 @@ func (h *handler) getStoreIds(c *gin.Context) []int32 {
 	return ids
 }
 
+// GetStores returns the calling user's accessible stores wrapped in
+// the standard cursor-pagination envelope. Stores per company are
+// bounded (typically <10), so we return the full set in one page —
+// no real seek; HasMore is always false. Keeping the envelope shape
+// keeps the wire contract uniform across all list endpoints.
 func (h *handler) GetStores(c *gin.Context) {
-	c.JSON(http.StatusOK, h.getStores(GetSessionInfo(c)))
+	stores := h.getStores(GetSessionInfo(c))
+	if stores == nil {
+		stores = []Store{}
+	}
+	c.JSON(http.StatusOK, pagination.Envelope[Store]{Items: stores})
 }
 
 // ── GET /api/v2/store/:id ───────────────────────────────────────────────────

--- a/pkg/handlers/supplier.go
+++ b/pkg/handlers/supplier.go
@@ -1,8 +1,10 @@
 package handlers
 
 import (
+	"database/sql"
 	"ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"ifritah/web-service-gin/pkg/pagination"
 	"log"
 	"net/http"
 	"strconv"
@@ -28,30 +30,53 @@ type SupplierRequest struct {
 	Email                  *string          `json:"email"`
 }
 
+const supplierListSort = "-id"
+
 func (h *handler) GetAllSupplier(c *gin.Context) {
 
-	request := model.PaginationRequest{
-		PageSize: 10,
-		Page:     0,
-	}
+	request := model.PaginationRequest{}
 
 	if err := c.BindJSON(&request); err != nil {
 		log.Printf("GetAllSupplier: %v", err)
 		c.Status(http.StatusBadRequest)
 		return
 	}
+
+	listReq := listRequestFromPagination(request)
+	if err := listReq.Validate(supplierListSort); err != nil {
+		log.Printf("GetAllSupplier: %v", err)
+		c.Status(http.StatusBadRequest)
+		return
+	}
+
+	cur, _ := listReq.DecodedCursor()
+	cursorID := cursorIDOnly(cur)
+	var cursorIDNullable sql.NullInt64
+	if cursorID != nil {
+		cursorIDNullable = sql.NullInt64{Int64: int64(*cursorID), Valid: true}
+	}
+
+	limit := listReq.EffectiveLimit()
+
 	args := db.GetAllSupplierParams{
-		Limit:  request.PageSize,
-		Offset: request.Page * request.PageSize,
+		CursorID: cursorIDNullable,
+		Limit:    int32(limit + 1),
 	}
 
 	suppliers, err := h.queries.GetAllSupplier(c.Request.Context(), args)
 	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
+		log.Printf("GetAllSupplier: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 
-	c.IndentedJSON(http.StatusOK, suppliers)
+	envelope := pagination.BuildEnvelope(
+		suppliers,
+		limit,
+		supplierListSort,
+		func(s db.Supplier) []any { return []any{s.ID} },
+	)
+	c.IndentedJSON(http.StatusOK, envelope)
 }
 
 func (h *handler) GetSupplier(c *gin.Context) {

--- a/pkg/model/bill.go
+++ b/pkg/model/bill.go
@@ -28,9 +28,15 @@ type BillRequestFilter struct {
 	StoreIds  []int      `json:"store_ids"`
 	StartDate *time.Time `json:"start_date"`
 	EndDate   *time.Time `json:"end_date"`
-	Page      int        `json:"page_number"`
-	PageSize  int        `json:"page_size"`
-	Query     *string    `json:"query"`
+	// Cursor pagination (preferred). Empty Cursor + zero Limit falls
+	// back to the legacy Page/PageSize keys for one release.
+	Limit  int    `json:"limit"`
+	Cursor string `json:"cursor"`
+	Sort   string `json:"sort"`
+	// Legacy offset paging — accepted but ignored once Cursor is set.
+	Page     int     `json:"page_number"`
+	PageSize int     `json:"page_size"`
+	Query    *string `json:"query"`
 }
 
 type AddBillRequest struct {

--- a/pkg/model/pagination.go
+++ b/pkg/model/pagination.go
@@ -1,9 +1,22 @@
 package model
 
+// PaginationRequest is the shared list-endpoint request body. Both
+// keyset (Limit/Cursor/Sort) and the legacy offset keys (Page/PageSize)
+// are accepted; the handler picks one based on whether Cursor is set.
+//
+// Renaming or removing JSON keys here breaks the wire contract — keep
+// all keys here in lockstep with FE helpers/cursor.go and SEARCH_API.md.
 type PaginationRequest struct {
-	Query    *string `json:"query"`
-	Page     int32   `json:"page"`
-	PageSize int32   `json:"page_size"`
+	Query *string `json:"query"`
+	// Keyset pagination (preferred).
+	Limit  int32  `json:"limit"`
+	Cursor string `json:"cursor"`
+	Sort   string `json:"sort"`
+	// Legacy offset paging — accepted but ignored once Cursor is set.
+	Page     int32 `json:"page"`
+	PageSize int32 `json:"page_size"`
+	// Legacy alias for Page used by some FE callers (page_number).
+	PageNumber int32 `json:"page_number"`
 }
 
 type PaginationResponse struct {

--- a/pkg/pagination/cursor.go
+++ b/pkg/pagination/cursor.go
@@ -1,0 +1,150 @@
+// Package pagination implements the keyset/cursor pagination contract
+// shared with the frontend. The wire format is documented in the
+// afrita-go repo at api_docs/search/SEARCH_API.md §9 and the matching
+// FE helper at helpers/cursor.go — keep this file in lockstep with that
+// one (struct shape, JSON keys, base64 variant).
+//
+// Why keyset and not OFFSET:
+//   - OFFSET scans + discards N rows on every request. It defeats any
+//     covering index and silently skips/duplicates rows under concurrent
+//     writes. (Markus Winand, use-the-index-luke.com/no-offset; same
+//     reasoning Stripe, Slack and GitHub used when they dropped page
+//     numbers from their list APIs.)
+//   - Keyset reads the next page by `WHERE (sort_value, id) < (?, ?)`,
+//     which the optimizer can serve as a single range scan on the
+//     composite index — O(log n) seek + O(limit) read.
+package pagination
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Cursor is the opaque pagination token. Tiny on purpose because it
+// travels in URLs and HTML fragments — the FE never inspects fields,
+// it just round-trips the encoded string.
+type Cursor struct {
+	// K is the keyset tuple of the boundary row, ordered the same way
+	// as the ORDER BY clause. The trailing element is always the row
+	// id (tie-breaker so rows with identical sort values still get a
+	// deterministic order).
+	//
+	// The slice carries interface{} so dates, ints and strings all
+	// round-trip without a per-resource cursor type.
+	K []any `json:"k"`
+
+	// S is the canonical sort spec this cursor was minted under, e.g.
+	// "-effective_date". Empty means "default sort for the resource".
+	// The BE rejects a cursor whose S doesn't match the request's sort
+	// — otherwise the seek predicate would walk through the wrong
+	// index and skip/duplicate rows.
+	S string `json:"s,omitempty"`
+
+	// D is the direction relative to K: "after" for next-page, "before"
+	// for previous-page. Empty defaults to "after".
+	D string `json:"d,omitempty"`
+}
+
+// Direction constants. Keep these in sync with helpers/cursor.go on
+// the FE so the contract stays symmetric.
+const (
+	DirectionAfter  = "after"
+	DirectionBefore = "before"
+)
+
+// Direction returns the cursor direction, defaulting to "after".
+func (c Cursor) Direction() string {
+	if c.D == "" {
+		return DirectionAfter
+	}
+	return c.D
+}
+
+// LastID returns the trailing id component of the keyset tuple. JSON
+// numbers come back as either float64 (default) or json.Number when
+// the decoder was set with UseNumber(); we accept both because the FE
+// uses UseNumber and the BE typically does not.
+func (c Cursor) LastID() (int64, bool) {
+	if len(c.K) == 0 {
+		return 0, false
+	}
+	switch v := c.K[len(c.K)-1].(type) {
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	case int32:
+		return int64(v), true
+	case float64:
+		return int64(v), true
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, false
+		}
+		return i, true
+	}
+	return 0, false
+}
+
+// SortValue returns the leading sort-value component of the keyset
+// tuple — i.e. K[0] when the cursor has at least 2 elements. For
+// id-only cursors (single-element K) it returns nil so callers can
+// short-circuit into a pure id-only seek.
+func (c Cursor) SortValue() any {
+	if len(c.K) < 2 {
+		return nil
+	}
+	return c.K[0]
+}
+
+// ErrInvalidCursor is returned when the input is not a valid cursor.
+// Callers should map this to HTTP 400 — the user probably hand-edited
+// the URL.
+var ErrInvalidCursor = errors.New("invalid cursor")
+
+// Encode renders a Cursor as a URL-safe base64 JSON string. Empty
+// cursors return "" so callers can treat empty == "first page".
+func Encode(c Cursor) string {
+	if len(c.K) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		// Can't fail for our shape. If it ever does we'd rather lose
+		// pagination than crash a list page — the caller will treat ""
+		// as "no more pages".
+		return ""
+	}
+	return base64.RawURLEncoding.EncodeToString(raw)
+}
+
+// Decode parses a string previously returned by Encode. An empty
+// input is a valid first-page cursor and yields the zero value
+// without an error.
+//
+// We accept both raw (no padding, RFC 4648 §5) and padded base64url
+// because some HTTP clients and middlewares re-add the padding.
+func Decode(s string) (Cursor, error) {
+	if s == "" {
+		return Cursor{}, nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(s)
+	if err != nil {
+		raw, err = base64.URLEncoding.DecodeString(s)
+		if err != nil {
+			return Cursor{}, fmt.Errorf("%w: base64: %v", ErrInvalidCursor, err)
+		}
+	}
+	var c Cursor
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	// UseNumber so big int64 ids don't lose precision in float64.
+	dec.UseNumber()
+	if err := dec.Decode(&c); err != nil {
+		return Cursor{}, fmt.Errorf("%w: json: %v", ErrInvalidCursor, err)
+	}
+	return c, nil
+}

--- a/pkg/pagination/cursor_test.go
+++ b/pkg/pagination/cursor_test.go
@@ -1,0 +1,175 @@
+package pagination
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	c := Cursor{K: []any{"2026-05-03T00:00:00Z", int64(518)}, S: "-effective_date", D: DirectionAfter}
+	enc := Encode(c)
+	if enc == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	got, err := Decode(enc)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.S != c.S || got.D != c.D {
+		t.Fatalf("metadata mismatch: %+v", got)
+	}
+	id, ok := got.LastID()
+	if !ok || id != 518 {
+		t.Fatalf("last id mismatch: got=%d ok=%v", id, ok)
+	}
+}
+
+func TestDecodeEmptyIsZero(t *testing.T) {
+	got, err := Decode("")
+	if err != nil {
+		t.Fatalf("decode empty: %v", err)
+	}
+	if len(got.K) != 0 {
+		t.Fatalf("expected zero cursor, got %+v", got)
+	}
+}
+
+func TestDecodeMalformedReturnsErrInvalidCursor(t *testing.T) {
+	_, err := Decode("!!not-base64!!")
+	if !errors.Is(err, ErrInvalidCursor) {
+		t.Fatalf("want ErrInvalidCursor, got %v", err)
+	}
+}
+
+func TestDecodeAcceptsPaddedBase64(t *testing.T) {
+	// Pre-canned cursor with std-padded base64 (URLEncoding, not RawURL).
+	raw, _ := json.Marshal(Cursor{K: []any{int64(7)}, D: DirectionAfter})
+	// stdlib URLEncoding adds '=' padding; ensure Decode accepts it.
+	std := base64URLEncodeWithPadding(raw)
+	got, err := Decode(std)
+	if err != nil {
+		t.Fatalf("decode padded: %v", err)
+	}
+	if id, _ := got.LastID(); id != 7 {
+		t.Fatalf("padded id mismatch: %d", id)
+	}
+}
+
+// helper kept local to the test to avoid leaking a padded encoder
+// into the package surface.
+func base64URLEncodeWithPadding(b []byte) string {
+	const tbl = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+	var out []byte
+	n := len(b)
+	for i := 0; i < n; i += 3 {
+		switch n - i {
+		case 1:
+			b0 := b[i]
+			out = append(out, tbl[b0>>2], tbl[(b0&0x03)<<4], '=', '=')
+		case 2:
+			b0, b1 := b[i], b[i+1]
+			out = append(out, tbl[b0>>2], tbl[((b0&0x03)<<4)|(b1>>4)], tbl[(b1&0x0f)<<2], '=')
+		default:
+			b0, b1, b2 := b[i], b[i+1], b[i+2]
+			out = append(out, tbl[b0>>2], tbl[((b0&0x03)<<4)|(b1>>4)], tbl[((b1&0x0f)<<2)|(b2>>6)], tbl[b2&0x3f])
+		}
+	}
+	return string(out)
+}
+
+func TestEffectiveLimit(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ListRequest
+		want int
+	}{
+		{"default when zero", ListRequest{}, DefaultLimit},
+		{"legacy page_size", ListRequest{PageSize: 7}, 7},
+		{"new limit beats legacy", ListRequest{Limit: 10, PageSize: 99}, 10},
+		{"clamped to max", ListRequest{Limit: 9999}, MaxLimit},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := tc.in
+			if got := r.EffectiveLimit(); got != tc.want {
+				t.Fatalf("got %d want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateSortMismatchRejected(t *testing.T) {
+	c := Cursor{K: []any{"2026", int64(1)}, S: "-effective_date"}
+	r := ListRequest{Limit: 25, Cursor: Encode(c), Sort: "-id"}
+	if err := r.Validate("-effective_date"); !errors.Is(err, ErrSortMismatch) {
+		t.Fatalf("want ErrSortMismatch, got %v", err)
+	}
+}
+
+func TestValidateSortDefaultAccepted(t *testing.T) {
+	c := Cursor{K: []any{"2026", int64(1)}, S: "-effective_date"}
+	r := ListRequest{Limit: 25, Cursor: Encode(c)}
+	if err := r.Validate("-effective_date"); err != nil {
+		t.Fatalf("default sort should match: %v", err)
+	}
+}
+
+func TestValidateLimitTooLarge(t *testing.T) {
+	r := ListRequest{Limit: MaxLimit + 1}
+	if err := r.Validate("-id"); !errors.Is(err, ErrLimitTooLarge) {
+		t.Fatalf("want ErrLimitTooLarge, got %v", err)
+	}
+}
+
+func TestBuildEnvelopeHasMore(t *testing.T) {
+	rows := []int{1, 2, 3, 4} // limit=3, +1 row signals more
+	env := BuildEnvelope(rows, 3, "-id", func(v int) []any { return []any{int64(v)} })
+	if !env.HasMore {
+		t.Fatal("want HasMore=true")
+	}
+	if len(env.Items) != 3 {
+		t.Fatalf("want 3 items, got %d", len(env.Items))
+	}
+	if env.NextCursor == "" {
+		t.Fatal("want next_cursor")
+	}
+	got, _ := Decode(env.NextCursor)
+	if id, _ := got.LastID(); id != 3 {
+		t.Fatalf("next cursor should point at last kept row, got %d", id)
+	}
+}
+
+func TestBuildEnvelopeNoMore(t *testing.T) {
+	rows := []int{1, 2}
+	env := BuildEnvelope(rows, 5, "-id", func(v int) []any { return []any{int64(v)} })
+	if env.HasMore {
+		t.Fatal("want HasMore=false")
+	}
+	if env.NextCursor != "" {
+		t.Fatal("want empty next_cursor when no more pages")
+	}
+}
+
+func TestBuildEnvelopeEmptyEmitsArrayNotNull(t *testing.T) {
+	env := BuildEnvelope[int](nil, 5, "-id", nil)
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Must contain `"items":[]` not `"items":null` — FE parsers expect
+	// an array.
+	want := `"items":[]`
+	if got := string(b); !contains(got, want) {
+		t.Fatalf("envelope should emit %s, got %s", want, got)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/pagination/listquery.go
+++ b/pkg/pagination/listquery.go
@@ -1,0 +1,168 @@
+package pagination
+
+import (
+	"errors"
+	"strings"
+)
+
+// MaxLimit is the BE hard cap on page size. The FE caps itself at 50
+// per the SEARCH_API.md contract — this 100 is a defence-in-depth cap
+// for any non-FE caller (curl, scripts, integration tests).
+const MaxLimit = 100
+
+// DefaultLimit is the page size used when a request omits `limit`.
+const DefaultLimit = 25
+
+// ListRequest is the shared request shape for every cursor-paginated
+// list endpoint. The legacy keys (PageNumber/PageSize) are accepted
+// for one release so existing FE code paths keep working while the
+// envelope rolls out — they are ignored once Cursor is non-empty.
+//
+// Resource-specific filters (StoreIds, VoucherType, etc.) live on the
+// per-resource request types; they are not part of this shared shape
+// because each list has its own filter columns.
+type ListRequest struct {
+	// New, preferred wire keys.
+	Limit  int    `json:"limit"`
+	Cursor string `json:"cursor"`
+	Sort   string `json:"sort"`
+
+	// Search term. Honored server-side per FE §4 (Search-on-list).
+	Query *string `json:"query"`
+
+	// Legacy keys — kept so this PR is wire-compatible with clients
+	// that haven't switched to cursors yet. Ignored when Cursor != "".
+	PageNumber int `json:"page_number"`
+	PageSize   int `json:"page_size"`
+}
+
+// EffectiveLimit clamps the requested limit into [1, MaxLimit] and
+// applies DefaultLimit when neither limit nor page_size is set.
+func (r *ListRequest) EffectiveLimit() int {
+	n := r.Limit
+	if n <= 0 {
+		n = r.PageSize
+	}
+	if n <= 0 {
+		return DefaultLimit
+	}
+	if n > MaxLimit {
+		return MaxLimit
+	}
+	return n
+}
+
+// ErrLimitTooLarge is returned when a caller asks for more rows than
+// MaxLimit. Per the FE contract this is a 400 — we don't silently
+// clamp because that would hide bugs in client pagination code.
+var ErrLimitTooLarge = errors.New("limit exceeds max")
+
+// ErrSortMismatch is returned when the cursor's S field disagrees
+// with the request's Sort. The seek predicate would walk through the
+// wrong index, so we reject rather than silently re-sort.
+var ErrSortMismatch = errors.New("cursor sort spec does not match request sort")
+
+// Validate checks limit + cursor sort consistency. expectedSort is the
+// canonical sort spec for the resource (e.g. "-effective_date" for
+// invoices, "-id" for catalogue tables). If the request omits sort
+// the resource default is assumed.
+func (r *ListRequest) Validate(expectedSort string) error {
+	if r.Limit > MaxLimit {
+		return ErrLimitTooLarge
+	}
+	if r.Cursor == "" {
+		return nil
+	}
+	c, err := Decode(r.Cursor)
+	if err != nil {
+		return err
+	}
+	wantSort := r.Sort
+	if wantSort == "" {
+		wantSort = expectedSort
+	}
+	if c.S != "" && c.S != wantSort {
+		return ErrSortMismatch
+	}
+	return nil
+}
+
+// DecodedCursor returns the parsed cursor or the zero Cursor when the
+// request has no cursor. Call Validate first — this method does not
+// re-check sort consistency.
+func (r *ListRequest) DecodedCursor() (Cursor, error) {
+	return Decode(r.Cursor)
+}
+
+// SortSpec returns the resolved sort spec for the request. When the
+// request omits sort the resource default is returned.
+func (r *ListRequest) SortSpec(defaultSort string) string {
+	if r.Sort == "" {
+		return defaultSort
+	}
+	return r.Sort
+}
+
+// SortColumn parses a sort spec like "-effective_date" into the bare
+// column name and the direction. A leading '-' means DESC; otherwise
+// ASC. This is intentionally tiny and only handles the single-column
+// specs the FE actually emits — multi-column sort isn't in the
+// contract yet.
+func SortColumn(spec string) (col string, desc bool) {
+	if strings.HasPrefix(spec, "-") {
+		return spec[1:], true
+	}
+	return spec, false
+}
+
+// Envelope is the new response shape. Generic on the item type so
+// each handler keeps its strongly-typed slice without an interface{}
+// hop. Keep the JSON tags identical to the FE's tryDecodeEnvelope
+// detection rule — adding/renaming a field here breaks the contract.
+type Envelope[T any] struct {
+	Items      []T    `json:"items"`
+	NextCursor string `json:"next_cursor"`
+	PrevCursor string `json:"prev_cursor"`
+	HasMore    bool   `json:"has_more"`
+}
+
+// BuildEnvelope applies the +1 row trick: callers fetch limit+1 rows
+// and pass them to this helper. If we got back limit+1, the extra row
+// is dropped and HasMore is set to true.
+//
+// keyFn extracts the keyset tuple for the *last* item kept on the
+// page; the result becomes NextCursor. If keyFn returns a nil/empty
+// slice, NextCursor stays empty (signals "no more pages").
+//
+// PrevCursor mirroring is left to the caller because not every list
+// supports backward paging — the FE today only walks forward via
+// next_cursor, so most resources can pass an empty string.
+func BuildEnvelope[T any](
+	rows []T,
+	limit int,
+	sortSpec string,
+	keyFn func(T) []any,
+) Envelope[T] {
+	hasMore := false
+	if len(rows) > limit {
+		rows = rows[:limit]
+		hasMore = true
+	}
+	env := Envelope[T]{Items: rows, HasMore: hasMore}
+	// Always serialize Items as [] not null even when empty — Go would
+	// otherwise emit `"items": null`, which trips up some FE decoders.
+	if env.Items == nil {
+		env.Items = []T{}
+	}
+	if hasMore && len(rows) > 0 && keyFn != nil {
+		key := keyFn(rows[len(rows)-1])
+		if len(key) > 0 {
+			env.NextCursor = Encode(Cursor{
+				K: key,
+				S: sortSpec,
+				D: DirectionAfter,
+			})
+		}
+	}
+	return env
+}


### PR DESCRIPTION
## What this does

Replaces OFFSET pagination with **keyset (seek) pagination** for every cursor-paginated list endpoint, per the FE contract in [chat/2026-05-03_frontend-to-backend_cursor-pagination.md](chat/2026-05-03_frontend-to-backend_cursor-pagination.md) and afrita-go's `api_docs/search/SEARCH_API.md` §9.

Pages are now **O(log n) seek + O(limit) read** regardless of position, instead of O(offset) per request. No more `COUNT(*)` on every list page, and no more silent skip/duplicate window under concurrent writes.

Reference: Markus Winand, [use-the-index-luke.com/no-offset](https://use-the-index-luke.com/no-offset). Same wire shape as Stripe/Slack/GitHub list APIs.

## Endpoints migrated (9)

| Endpoint | Sort key | Index |
|---|---|---|
| `POST /api/v2/bill/all` | `-effective_date` | new `idx_bill_keyset` |
| `POST /api/v2/purchase_bill/all` | `-effective_date` | new `idx_pb_keyset` |
| `POST /api/v2/order/all` | `-created_at` | new `idx_orders_keyset` |
| `POST /api/v2/cash_voucher/all` | `-effective_date` | new `idx_cv_keyset` |
| `POST /api/v2/client/all` | `-updated_at` | new `idx_client_keyset` |
| `POST /api/v2/supplier/all` | `-id` | PK |
| `POST /api/v2/product/all` | `-id` | PK |
| `POST /api/v2/branch/all` | `id` | PK |
| `GET /api/v2/stores/all` | — (bounded set, single page) | n/a |

## Bug fix folded in

`GetAllBill` had a UNION that **duplicated every bill that had a credit_note row** (one row from the INNER JOIN, one from a separate LEFT-JOIN-credit_note SELECT, then UNION-ed). Replaced with a single `LEFT JOIN credit_note` so `cn.state` is non-null when present, NULL otherwise.

## Migration

`pkg/db/migrations/0003_keyset_indexes.sql` adds composite seek indexes for the date-sorted lists. Idempotent (gated against information_schema, same pattern as 0002). Apply with the existing migration runner.

## Backwards compat

- **Request**: legacy `page_number` / `page_size` still parsed; ignored once `cursor` is set.
- **Response**: every endpoint now emits the new envelope `{items, next_cursor, prev_cursor, has_more}`; FE detects this automatically per their `tryDecodeEnvelope` rule. The auth wrapper `{detail: …}` still falls through to the legacy decoder, so unmigrated FE pages keep working.

## Out of scope (intentionally deferred)

- **FULLTEXT/ngram** for hybrid search (FE §3) — separate PR; needs a server-level `innodb_ft_min_token_size` discussion that's orthogonal to pagination.
- **Rename `merchant_id` → `created_by_user_id`** — 139 occurrences across 7+ tables, mostly in code paths unrelated to pagination (cash voucher post/approve, supplier aging reports, journal entries, dashboards). Pure taxonomy, zero perf impact. Cleaner as a follow-up.
- **`prev_cursor`** deep paging — emitted empty for now; FE only walks forward today.

## Verification

- `go build ./...` clean.
- `go test ./pkg/pagination/...` covers cursor round-trip, sort-mismatch rejection, padded base64 acceptance, +1 row trick, empty envelope serializing as `[]` not `null`.
- Migration applied locally; `SHOW INDEXES FROM bill` confirms `idx_bill_keyset (effective_date DESC, id DESC)` is present.
- EXPLAIN on the seeded 2-row dev DB falls back to `ALL` (table too small for the optimizer to bother with the index); will re-EXPLAIN once staging has realistic volume.
