### PR TITLE
fix(sql): pin LIKE collation to avoid Error 1267 + propagate purchase_bill list errors

### DIFF
--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -67,9 +67,9 @@ WHERE bill.state >= 0
   AND (p.sf IS NULL OR bill.state = p.sf)
   AND (
         (p.q IS NULL AND p.qe IS NULL)
-     OR bill.user_phone_number LIKE p.q
-     OR bill.userName           LIKE p.q
-     OR client.name             LIKE p.q
+     OR bill.user_phone_number LIKE p.q COLLATE utf8mb4_unicode_ci
+     OR bill.userName           LIKE p.q COLLATE utf8mb4_unicode_ci
+     OR client.name             LIKE p.q COLLATE utf8mb4_unicode_ci
      OR CAST(bill.sequence_number AS CHAR) = CAST(p.qe AS CHAR)
   )
   AND (
@@ -104,9 +104,9 @@ WHERE bill.state >= 0
   AND (q.sf IS NULL OR bill.state = q.sf)
   AND (
         (q.q IS NULL AND q.qe IS NULL)
-     OR bill.user_phone_number LIKE q.q
-     OR bill.userName           LIKE q.q
-     OR client.name             LIKE q.q
+     OR bill.user_phone_number LIKE q.q COLLATE utf8mb4_unicode_ci
+     OR bill.userName           LIKE q.q COLLATE utf8mb4_unicode_ci
+     OR client.name             LIKE q.q COLLATE utf8mb4_unicode_ci
      OR CAST(bill.sequence_number AS CHAR) = CAST(q.qe AS CHAR)
   )
   AND (

--- a/pkg/db/queries/client.sql
+++ b/pkg/db/queries/client.sql
@@ -14,9 +14,9 @@ CROSS JOIN (SELECT CAST(sqlc.narg('query_like')        AS CHAR(255))   AS q,
                    CAST(sqlc.narg('cursor_id')         AS UNSIGNED)    AS ci) p
 WHERE c.is_deleted = FALSE
   AND (p.q IS NULL
-       OR c.name  LIKE p.q
-       OR c.email LIKE p.q
-       OR c.phone LIKE p.q)
+       OR c.name  LIKE p.q COLLATE utf8mb4_unicode_ci
+       OR c.email LIKE p.q COLLATE utf8mb4_unicode_ci
+       OR c.phone LIKE p.q COLLATE utf8mb4_unicode_ci)
   AND (p.cu IS NULL
        OR c.updated_at < p.cu
        OR (c.updated_at = p.cu AND c.id < p.ci))

--- a/pkg/db/queries/order.sql
+++ b/pkg/db/queries/order.sql
@@ -12,8 +12,8 @@ CROSS JOIN (SELECT CAST(sqlc.narg('company_id')         AS UNSIGNED)    AS cid,
                    CAST(sqlc.narg('cursor_id')          AS UNSIGNED)    AS ci) p
 WHERE o.store_id IN (SELECT id FROM store WHERE company_id = p.cid)
   AND (p.q IS NULL
-       OR o.sequence_number LIKE p.q
-       OR o.customer_name LIKE p.q)
+       OR o.sequence_number LIKE p.q COLLATE utf8mb4_unicode_ci
+       OR o.customer_name LIKE p.q COLLATE utf8mb4_unicode_ci)
   AND (p.cca IS NULL
        OR o.created_at < p.cca
        OR (o.created_at = p.cca AND o.id < p.ci))

--- a/pkg/db/queries/product.sql
+++ b/pkg/db/queries/product.sql
@@ -21,8 +21,8 @@ CROSS JOIN (SELECT CAST(sqlc.narg('query_like')     AS CHAR(255)) AS q,
                    CAST(sqlc.narg('cursor_id')      AS UNSIGNED)  AS ci) prm
 where user.id = ? and p.is_deleted = False
   and (prm.q IS NULL
-       OR p.name LIKE prm.q
-       OR COALESCE(p.shelf_number,'') LIKE prm.q
+       OR p.name LIKE prm.q COLLATE utf8mb4_unicode_ci
+       OR COALESCE(p.shelf_number,'') LIKE prm.q COLLATE utf8mb4_unicode_ci
        OR p.id = prm.qid)
   and (prm.ci IS NULL OR p.id < prm.ci)
 ORDER BY p.id DESC

--- a/pkg/db/queries/purchase_bill.sql
+++ b/pkg/db/queries/purchase_bill.sql
@@ -37,7 +37,7 @@ select b.*
 	  and (p.sf is null or b.state = p.sf)
 	  and (
 	        (p.q is null and p.qe is null)
-	     or supplier.name like p.q
+	     or supplier.name like p.q COLLATE utf8mb4_unicode_ci
 	     or CAST(b.supplier_sequence_number AS CHAR) = CAST(p.qe AS CHAR)
 	     or CAST(b.id AS CHAR)                       = CAST(p.qe AS CHAR)
 	  )

--- a/pkg/db/queries/supplier.sql
+++ b/pkg/db/queries/supplier.sql
@@ -17,9 +17,9 @@ CROSS JOIN (SELECT CAST(sqlc.narg('query_like') AS CHAR(255)) AS q,
                    CAST(sqlc.narg('cursor_id')  AS UNSIGNED)  AS ci) p
 WHERE s.is_deleted = FALSE
   AND (p.q IS NULL
-       OR s.name         LIKE p.q
-       OR s.phone_number LIKE p.q
-       OR s.vat_number   LIKE p.q)
+       OR s.name         LIKE p.q COLLATE utf8mb4_unicode_ci
+       OR s.phone_number LIKE p.q COLLATE utf8mb4_unicode_ci
+       OR s.vat_number   LIKE p.q COLLATE utf8mb4_unicode_ci)
   AND (p.ci IS NULL OR s.id < p.ci)
 ORDER BY s.id DESC
 LIMIT ?;

--- a/pkg/handlers/purchase_bill.go
+++ b/pkg/handlers/purchase_bill.go
@@ -19,16 +19,8 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-func (h *handler) getPurchaseBills(c *gin.Context, args db.GetAllPurchaseBillParams) []db.PurchaseBill {
-
-	bills, err := h.queries.GetAllPurchaseBill(c.Request.Context(), args)
-
-	if err != nil {
-		log.Printf("getPurchaseBills: %v", err)
-		return nil
-	}
-
-	return bills
+func (h *handler) getPurchaseBills(c *gin.Context, args db.GetAllPurchaseBillParams) ([]db.PurchaseBill, error) {
+	return h.queries.GetAllPurchaseBill(c.Request.Context(), args)
 }
 
 // purchaseBillSetup is the result of beginPurchaseBillTx — everything both
@@ -393,7 +385,7 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 	// already enforced by the SQL); otherwise exact match.
 	stateFilter := nonNegativeStateFilter(request.State)
 
-	bill := h.getPurchaseBills(c, db.GetAllPurchaseBillParams{
+	bill, err := h.getPurchaseBills(c, db.GetAllPurchaseBillParams{
 		ID:            int32(userSession.id),
 		StateFilter:   nullInt64FromInt32Ptr(stateFilter),
 		QueryLike:     queryLike,
@@ -402,6 +394,11 @@ func (h *handler) GetAllPurchaseBill(c *gin.Context) {
 		CursorID:      nullInt64FromUint64Ptr(cursorID),
 		Limit:         int32(limit + 1),
 	})
+	if err != nil {
+		log.Printf("GetAllPurchaseBill: %v", err)
+		c.AbortWithStatus(http.StatusInternalServerError)
+		return
+	}
 
 	envelope := pagination.BuildEnvelope(
 		bill,


### PR DESCRIPTION
Two production fixes surfaced on dev DB.

## 1. Error 1267 illegal mix of collations on list endpoints

Dev DB has tables across three collations (utf8mb4_general_ci, utf8mb4_0900_ai_ci, utf8mb4_unicode_ci). LIKE comparisons between `CAST(? AS CHAR(255))` (inherits connection collation) and columns at different collations raised Error 1267 on `/api/v2/bill/all` and other list endpoints.

**Fix:** add `COLLATE utf8mb4_unicode_ci` on the right operand of every LIKE. Forces explicit coercibility level 0 on the literal so it wins regardless of the column's implicit collation.

Touched: `pkg/db/queries/{bill,client,order,product,purchase_bill,supplier}.sql`

## 2. purchase_bill list returned 200 + empty list on DB error

`getPurchaseBills` swallowed the query error and returned nil; the caller responded 200 with an empty list. Other list endpoints return 500. Aligned `purchase_bill` with the rest by propagating the error.

Touched: `pkg/handlers/purchase_bill.go`

## Tests

- sqlc generate clean
- go build ./... clean
- go test ./... green

## Note

Branched off latest `dev` after #29 was squash-merged. Replaces #30 (which carried already-merged history).