### PR TITLE
fix(bill-search): split phone/name search; drop silent sequence-number reinterpretation

### DIFF
--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -17,18 +17,23 @@
 -- OR-tree is the canonical lex-compare seek predicate
 -- (Markus Winand, use-the-index-luke.com/no-offset).
 --
--- Search (query_like / query_seq_exact):
---   - query_like: pre-wrapped %term% used against userName,
---     user_phone_number, and client.name (LEFT JOIN already in place).
---   - query_seq_exact: integer value of q when q is all-digits (exact
---     match on sequence_number). NULL otherwise.
+-- Search (query_name_like / query_phone_digits):
+--   - query_name_like:    pre-wrapped %term% used against userName
+--     and client.name (LEFT JOIN already in place).
+--   - query_phone_digits: pre-wrapped %digits% (Arabic-Indic folded,
+--     non-digits stripped) compared against the digits-only form of
+--     bill.user_phone_number and client.phone via REGEXP_REPLACE.
+--     This makes "+966 51-234-5678", "00966512345678", "0512345678",
+--     "٠٥١٢٣٤٥٦٧٨" all match the same customer.
 -- All-NULL on the search args = "no search".
 --
--- NOTE: total exact-match was scoped here but pulled to a follow-up
--- (sqlc v1.31 emits a non-nullable decimal.Decimal narg for params
--- bound against a NOT-NULL decimal column even with CAST AS CHAR /
--- CONCAT). userName/phone/sequence/client.name covers the dominant
--- search intents in our usage data.
+-- NOTE: sequence_number search was intentionally removed. Previously
+-- any all-digit query was silently coerced to an exact sequence_number
+-- match, which caused phone-shaped searches like "0512345678" to
+-- surface unrelated invoices whose sequence_number happened to equal
+-- 512345678 (leading zero dropped by ParseUint). If sequence-number
+-- search is reintroduced it must come from a dedicated request field,
+-- not a heuristic on the free-text query.
 --
 -- state_filter (sqlc.narg('state_filter')):
 --   - NULL = "any non-deleted" (state >= 0). Default.
@@ -57,20 +62,24 @@ SELECT bill.id AS id,
 FROM bill
 JOIN credit_note cn ON cn.bill_id = bill.id
 LEFT JOIN client  ON client.id = bill.client_id
-CROSS JOIN (SELECT CAST(sqlc.narg('state_filter')      AS SIGNED)       AS sf,
-                   CAST(sqlc.narg('query_like')        AS CHAR(255))    AS q,
-                   CAST(sqlc.narg('query_seq_exact')   AS UNSIGNED)     AS qe,
-                   CAST(sqlc.narg('cursor_date')       AS DATETIME(6))  AS cd,
-                   CAST(sqlc.narg('cursor_id')         AS UNSIGNED)     AS ci,
-                   CAST(sqlc.narg('cursor_is_credit')  AS UNSIGNED)     AS cic) p
+CROSS JOIN (SELECT CAST(sqlc.narg('state_filter')        AS SIGNED)       AS sf,
+                   CAST(sqlc.narg('query_name_like')    AS CHAR(255))    AS qn,
+                   CAST(sqlc.narg('query_phone_digits') AS CHAR(32))     AS qp,
+                   CAST(sqlc.narg('cursor_date')        AS DATETIME(6))  AS cd,
+                   CAST(sqlc.narg('cursor_id')          AS UNSIGNED)     AS ci,
+                   CAST(sqlc.narg('cursor_is_credit')   AS UNSIGNED)     AS cic) p
 WHERE bill.state >= 0
   AND (p.sf IS NULL OR bill.state = p.sf)
   AND (
-        (p.q IS NULL AND p.qe IS NULL)
-     OR bill.user_phone_number LIKE p.q COLLATE utf8mb4_unicode_ci
-     OR bill.userName           LIKE p.q COLLATE utf8mb4_unicode_ci
-     OR client.name             LIKE p.q COLLATE utf8mb4_unicode_ci
-     OR CAST(bill.sequence_number AS CHAR) = CAST(p.qe AS CHAR)
+        (p.qn IS NULL AND p.qp IS NULL)
+     OR (p.qp IS NOT NULL AND (
+            REGEXP_REPLACE(IFNULL(bill.user_phone_number, ''), '[^0-9]+', '') LIKE p.qp
+         OR REGEXP_REPLACE(IFNULL(client.phone, ''),            '[^0-9]+', '') LIKE p.qp
+        ))
+     OR (p.qn IS NOT NULL AND (
+            bill.userName LIKE p.qn COLLATE utf8mb4_unicode_ci
+         OR client.name   LIKE p.qn COLLATE utf8mb4_unicode_ci
+        ))
   )
   AND (
         p.cd IS NULL
@@ -94,20 +103,24 @@ SELECT bill.id AS id,
        0 AS is_credit
 FROM bill
 LEFT JOIN client ON client.id = bill.client_id
-CROSS JOIN (SELECT CAST(sqlc.narg('state_filter')      AS SIGNED)       AS sf,
-                   CAST(sqlc.narg('query_like')        AS CHAR(255))    AS q,
-                   CAST(sqlc.narg('query_seq_exact')   AS UNSIGNED)     AS qe,
-                   CAST(sqlc.narg('cursor_date')       AS DATETIME(6))  AS cd,
-                   CAST(sqlc.narg('cursor_id')         AS UNSIGNED)     AS ci,
-                   CAST(sqlc.narg('cursor_is_credit')  AS UNSIGNED)     AS cic) q
+CROSS JOIN (SELECT CAST(sqlc.narg('state_filter')        AS SIGNED)       AS sf,
+                   CAST(sqlc.narg('query_name_like')    AS CHAR(255))    AS qn,
+                   CAST(sqlc.narg('query_phone_digits') AS CHAR(32))     AS qp,
+                   CAST(sqlc.narg('cursor_date')        AS DATETIME(6))  AS cd,
+                   CAST(sqlc.narg('cursor_id')          AS UNSIGNED)     AS ci,
+                   CAST(sqlc.narg('cursor_is_credit')   AS UNSIGNED)     AS cic) q
 WHERE bill.state >= 0
   AND (q.sf IS NULL OR bill.state = q.sf)
   AND (
-        (q.q IS NULL AND q.qe IS NULL)
-     OR bill.user_phone_number LIKE q.q COLLATE utf8mb4_unicode_ci
-     OR bill.userName           LIKE q.q COLLATE utf8mb4_unicode_ci
-     OR client.name             LIKE q.q COLLATE utf8mb4_unicode_ci
-     OR CAST(bill.sequence_number AS CHAR) = CAST(q.qe AS CHAR)
+        (q.qn IS NULL AND q.qp IS NULL)
+     OR (q.qp IS NOT NULL AND (
+            REGEXP_REPLACE(IFNULL(bill.user_phone_number, ''), '[^0-9]+', '') LIKE q.qp
+         OR REGEXP_REPLACE(IFNULL(client.phone, ''),            '[^0-9]+', '') LIKE q.qp
+        ))
+     OR (q.qn IS NOT NULL AND (
+            bill.userName LIKE q.qn COLLATE utf8mb4_unicode_ci
+         OR client.name   LIKE q.qn COLLATE utf8mb4_unicode_ci
+        ))
   )
   AND (
         q.cd IS NULL

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -123,7 +123,7 @@ func (h *handler) GetBills(c *gin.Context) {
 		return
 	}
 
-	queryLike, querySeqExact := buildLikeAndDigitsExact(request.Query)
+	queryNameLike, queryPhoneDigits := buildBillSearchParams(request.Query)
 	stateFilter := nonNegativeStateFilter(request.State)
 
 	cur, _ := listReq.DecodedCursor()
@@ -140,12 +140,12 @@ func (h *handler) GetBills(c *gin.Context) {
 	// generated params: the CAST(... AS UNSIGNED/SIGNED) wrapper in
 	// bill.sql forces sqlc to emit Null* types for the keyset cols.
 	args := db.GetAllBillParams{
-		StateFilter:    nullInt64FromInt32Ptr(stateFilter),
-		QueryLike:      queryLike,
-		QuerySeqExact:  nullInt64FromUint64Ptr(querySeqExact),
-		CursorDate:     cursorDate,
-		CursorID:       nullInt64FromUint64Ptr(cursorID),
-		CursorIsCredit: nullInt64FromAny(cursorIsCredit),
+		StateFilter:       nullInt64FromInt32Ptr(stateFilter),
+		QueryNameLike:     queryNameLike,
+		QueryPhoneDigits:  queryPhoneDigits,
+		CursorDate:        cursorDate,
+		CursorID:          nullInt64FromUint64Ptr(cursorID),
+		CursorIsCredit:    nullInt64FromAny(cursorIsCredit),
 		// +1 row signals has_more without a COUNT(*).
 		Limit: int32(limit + 1),
 	}

--- a/pkg/handlers/list_helpers.go
+++ b/pkg/handlers/list_helpers.go
@@ -115,6 +115,85 @@ func buildLikeAndDigitsExact(query *string) (like *string, digits *uint64) {
 	return like, digits
 }
 
+// foldDigits maps Arabic-Indic (٠-٩) and Extended Arabic-Indic (۰-۹)
+// digits to ASCII 0-9. Other runes are passed through unchanged.
+func foldDigits(s string) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		switch {
+		case r >= '\u0660' && r <= '\u0669': // ٠-٩
+			out = append(out, '0'+(r-'\u0660'))
+		case r >= '\u06F0' && r <= '\u06F9': // ۰-۹
+			out = append(out, '0'+(r-'\u06F0'))
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+// digitsOnly returns only the ASCII digits in s after folding Arabic
+// digit forms. Used to normalize phone-number search input on the
+// query side; the SQL strips the same set on the column side via
+// REGEXP_REPLACE.
+func digitsOnly(s string) string {
+	folded := foldDigits(s)
+	out := make([]byte, 0, len(folded))
+	for i := 0; i < len(folded); i++ {
+		if folded[i] >= '0' && folded[i] <= '9' {
+			out = append(out, folded[i])
+		}
+	}
+	return string(out)
+}
+
+// minPhoneSearchDigits is the minimum digit count below which we do
+// not treat a query as a phone-number search. Below this threshold
+// the digit string would match too broadly (e.g. "12" appears in
+// thousands of phone numbers).
+const minPhoneSearchDigits = 4
+
+// buildBillSearchParams splits a free-text query into a name LIKE
+// and a digits-only phone fragment. Either may be nil.
+//
+//   - phoneDigits: %digits% wrapper, set when the query yields at
+//     least minPhoneSearchDigits digits after folding/stripping.
+//     Compared in SQL against REGEXP_REPLACE(phone, '[^0-9]+', '')
+//     so input format does not have to match storage format.
+//   - nameLike:    %query% wrapper, set when the query contains any
+//     non-digit (i.e. it could be a name) OR when no phoneDigits
+//     was produced (so a short numeric query still finds a name).
+//
+// The previous helper silently ParseUint'd the entire query into a
+// sequence_number match, which made phone-shaped searches like
+// "0512345678" return invoice #512345678. That heuristic is gone;
+// sequence-number search now requires a dedicated request field.
+func buildBillSearchParams(query *string) (nameLike *string, phoneDigits *string) {
+	if query == nil || *query == "" {
+		return nil, nil
+	}
+	q := *query
+	digits := digitsOnly(q)
+	if len(digits) >= minPhoneSearchDigits {
+		p := "%" + digits + "%"
+		phoneDigits = &p
+	}
+	hasNonDigit := false
+	for _, r := range foldDigits(q) {
+		if r < '0' || r > '9' {
+			if r != ' ' && r != '-' && r != '+' && r != '(' && r != ')' {
+				hasNonDigit = true
+				break
+			}
+		}
+	}
+	if hasNonDigit || phoneDigits == nil {
+		s := "%" + q + "%"
+		nameLike = &s
+	}
+	return nameLike, phoneDigits
+}
+
 // nonNegativeStateFilter returns nil for negative state; otherwise returns the value.
 func nonNegativeStateFilter(state *int32) *int32 {
 	if state == nil || *state < 0 {

--- a/pkg/handlers/list_helpers_test.go
+++ b/pkg/handlers/list_helpers_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import "testing"
+
+func strPtr(s string) *string { return &s }
+
+func TestBuildBillSearchParams_PhoneShapedQuery(t *testing.T) {
+	// Regression: "0512345678" used to be ParseUint'd into 512345678
+	// (leading zero dropped) and matched against bill.sequence_number,
+	// surfacing unrelated invoices. After the fix, a phone-shaped
+	// query must produce a digits-only phone wrapper and never a
+	// sequence-number match.
+	name, phone := buildBillSearchParams(strPtr("0512345678"))
+	if phone == nil || *phone != "%0512345678%" {
+		t.Fatalf("expected phone digits %%0512345678%%, got %v", phone)
+	}
+	// "0512345678" has no non-digits, so we should not also do a
+	// name LIKE search (precision: phone-shaped → phone fields only).
+	if name != nil {
+		t.Fatalf("expected nil name like for pure-digit query, got %q", *name)
+	}
+}
+
+func TestBuildBillSearchParams_FormattedPhone(t *testing.T) {
+	// "+966 51-234 5678" must normalize to digits-only
+	// "966512345678" so SQL REGEXP_REPLACE can match storage forms
+	// like "+966512345678" or "0512345678".
+	_, phone := buildBillSearchParams(strPtr("+966 51-234 5678"))
+	if phone == nil || *phone != "%966512345678%" {
+		t.Fatalf("expected %%966512345678%%, got %v", phone)
+	}
+}
+
+func TestBuildBillSearchParams_ArabicIndicDigits(t *testing.T) {
+	// "٠٥١٢٣٤٥٦٧٨" must fold to "0512345678".
+	_, phone := buildBillSearchParams(strPtr("٠٥١٢٣٤٥٦٧٨"))
+	if phone == nil || *phone != "%0512345678%" {
+		t.Fatalf("expected %%0512345678%%, got %v", phone)
+	}
+}
+
+func TestBuildBillSearchParams_NameQuery(t *testing.T) {
+	name, phone := buildBillSearchParams(strPtr("Ahmad"))
+	if phone != nil {
+		t.Fatalf("name query should not produce phone digits, got %q", *phone)
+	}
+	if name == nil || *name != "%Ahmad%" {
+		t.Fatalf("expected name LIKE %%Ahmad%%, got %v", name)
+	}
+}
+
+func TestBuildBillSearchParams_MixedQuery(t *testing.T) {
+	// Mixed alphanumeric: should still try both (name LIKE original
+	// query, phone digits from the digit run).
+	name, phone := buildBillSearchParams(strPtr("Ali 0512345678"))
+	if phone == nil || *phone != "%0512345678%" {
+		t.Fatalf("expected phone %%0512345678%%, got %v", phone)
+	}
+	if name == nil || *name != "%Ali 0512345678%" {
+		t.Fatalf("expected name LIKE %%Ali 0512345678%%, got %v", name)
+	}
+}
+
+func TestBuildBillSearchParams_TooShortForPhone(t *testing.T) {
+	// "12" is below minPhoneSearchDigits — must not be treated as
+	// phone digits (would match thousands of phone numbers).
+	name, phone := buildBillSearchParams(strPtr("12"))
+	if phone != nil {
+		t.Fatalf("short numeric must not produce phone digits, got %q", *phone)
+	}
+	if name == nil || *name != "%12%" {
+		t.Fatalf("expected fallback name LIKE %%12%%, got %v", name)
+	}
+}
+
+func TestBuildBillSearchParams_Empty(t *testing.T) {
+	name, phone := buildBillSearchParams(nil)
+	if name != nil || phone != nil {
+		t.Fatalf("nil query must yield nil/nil, got name=%v phone=%v", name, phone)
+	}
+	name, phone = buildBillSearchParams(strPtr(""))
+	if name != nil || phone != nil {
+		t.Fatalf("empty query must yield nil/nil, got name=%v phone=%v", name, phone)
+	}
+}


### PR DESCRIPTION
## The bug

Searching `0512345678` on `/api/v2/bill/all` returned an invoice for a customer named "RegressionTest" with no phone and no notes — completely unrelated to the search input.

**Root cause:** the free-text `q` was being run through `strconv.ParseUint`. `0512345678` parsed to `512345678` (leading zero dropped), which then matched `bill.sequence_number = 512345678` on an unrelated invoice. The OR-chain made any of {phone substring, userName substring, client.name substring, sequence_number exact} a match, so a sequence-number hit on a totally different customer was indistinguishable from a real phone hit.

Two more issues compounded it:

1. **Phone storage is unnormalized.** Real data has `+966512345678`, `00966512345678`, `0512345678`, `05 1234 5678`. `LIKE %0512345678%` only matched the third format.
2. **No Arabic-Indic digit folding.** `٠٥١٢٣٤٥٦٧٨` and `0512345678` were two different strings.

## Fix

Replaced `query_like + query_seq_exact` with two purpose-built params, both nullable:

- **`query_phone_digits`** — digits-only wrapper. Built by folding Arabic-Indic (`٠-٩`) and Extended Arabic-Indic (`۰-۹`) to ASCII, stripping all non-digits. Compared in SQL via `REGEXP_REPLACE(phone, '[^0-9]+', '') LIKE ?`, so storage format no longer matters. Set only when the query yields ≥4 digits (avoids matching everything on `12`).
- **`query_name_like`** — `%term%` against `bill.userName` and `client.name`. Skipped for pure phone-shaped queries so phone results aren't polluted by accidental name partials.

Sequence-number search via free-text `q` was **removed**. It was always a footgun (every phone is also a number). If we want sequence-number search back, it must come from a dedicated request field.

Also added `client.phone` to the searched set — previously we only matched `bill.user_phone_number`, so a customer who saved their phone on the client record but not on the bill was unfindable.

## Files

- `pkg/db/queries/bill.sql` — split params; phone match via `REGEXP_REPLACE`; doc rewrite.
- `pkg/handlers/list_helpers.go` — new `buildBillSearchParams`, `digitsOnly`, `foldDigits`. Old `buildLikeAndDigitsExact` kept for other endpoints (their use of digits-as-id is intentional, not heuristic).
- `pkg/handlers/bill.go` — caller updated.
- `pkg/handlers/list_helpers_test.go` — 7 new unit tests pinning behaviour.

## Tests

```
=== RUN   TestBuildBillSearchParams_PhoneShapedQuery       PASS
=== RUN   TestBuildBillSearchParams_FormattedPhone         PASS
=== RUN   TestBuildBillSearchParams_ArabicIndicDigits      PASS
=== RUN   TestBuildBillSearchParams_NameQuery              PASS
=== RUN   TestBuildBillSearchParams_MixedQuery             PASS
=== RUN   TestBuildBillSearchParams_TooShortForPhone       PASS
=== RUN   TestBuildBillSearchParams_Empty                  PASS
```

`sqlc generate`, `go build ./...`, `go test ./...` all green.

## Out of scope (deferred)

- Same fix for `purchase_bill`, `client`, `order`, `product`, `supplier` list endpoints — they use the old helper but their digit-as-id semantics differ per domain (supplier sequence number, product id) and need their own analysis. Will land per-domain.
- Relevance ranking (`ORDER BY score DESC`) — the precision improvement here makes results "shorter" as the user requested, and date-desc on a tight result set behaves like "most recent matching customer first". A real BM25/score-based ranking is a Phase 2 problem (Meilisearch sidecar) once we have evidence that precision alone isn't enough.