### PR TITLE
chore(docker): docker-compose for local dev (mysql + nats + app)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,58 @@
+# =============================================================================
+# ifritah-go — example environment for local development
+# =============================================================================
+# Copy to .env (which is gitignored) and edit:
+#   cp .env.example .env
+#
+# Run the full stack (MySQL + the API) with:
+#   docker compose up --build
+#
+# The variable names below match what the Go code reads with os.Getenv() —
+# do not rename them without updating the source.
+# =============================================================================
+
+# ---- HTTP server -------------------------------------------------------------
+# Port the Gin router listens on inside the container. The published port in
+# docker-compose.yml is fixed to 8090; change both if you change this.
+SERVER_PORT=8090
+
+# Optional URL prefix for all routes (e.g. "/api/v2"). Empty means none.
+BASEURL=
+
+# ---- MySQL -------------------------------------------------------------------
+# When run via docker compose, the app talks to the bundled `mysql` service
+# on its container hostname. Override HOST to point at an external MySQL
+# (e.g. host.docker.internal:3306) if you prefer.
+HOST=mysql:3306
+DBUSER=ifritah
+PASSWORD=ifritah
+DBNAME=ifritah
+
+# Set to "true" to require TLS to MySQL. Leave blank for local plaintext.
+DB_TLS=false
+
+# IANA timezone the driver uses to parse DATETIME columns.
+DB_TIMEZONE=Asia/Riyadh
+
+# Optional pool tuning (defaults shown):
+#DB_MAX_OPEN_CONNS=50
+#DB_MAX_IDLE_CONNS=10
+#DB_CONN_MAX_LIFETIME_SEC=180
+#DB_CONN_MAX_IDLE_SEC=60
+
+# ---- Auth --------------------------------------------------------------------
+# Secret used to sign JWTs. Generate with:  openssl rand -hex 32
+# NOTE: variable name keeps the upstream spelling (JWT_SECERT_KEY).
+JWT_SECERT_KEY=replace-me-with-openssl-rand-hex-32
+
+# ---- VIN lookup (vehicle-databases.com) --------------------------------------
+# Leave blank locally — VIN endpoints will return errors but the rest of the
+# API works. Provide both values in production.
+VEHICLE_DATABASES=
+VEHICLE_DATABASES_KEY=
+
+# ---- NATS / JetStream --------------------------------------------------------
+# The ZATCA publisher (pkg/handlers/pub.go) connects here on startup.
+# In compose this points at the bundled `nats` service; the value is also
+# overridden by docker-compose.yml so the example below mainly documents it.
+NATS_URL=nats://nats:4222

--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ ifritah
 ifritah.exe
 _*.ps1
 _*.sql
-docker-compose.yml
 docker/
 cmd/hashpw/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,92 @@
+# =============================================================================
+# Local development stack for ifritah-go
+# =============================================================================
+# Brings up MySQL 8 (with schema + migrations seeded on first init) and the
+# API. Intended for local dev and integration testing — NOT for production.
+#
+# Quick start:
+#   cp .env.example .env
+#   docker compose up --build
+#
+# The MySQL data volume persists across runs. To start clean:
+#   docker compose down -v
+# =============================================================================
+
+services:
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: ${DBNAME:-ifritah}
+      MYSQL_USER: ${DBUSER:-ifritah}
+      MYSQL_PASSWORD: ${PASSWORD:-ifritah}
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+      - --default-time-zone=+03:00
+    ports:
+      # Host port 13306 to avoid clashing with a local MySQL on 3306. Connect
+      # from the host (e.g. with a GUI) using 127.0.0.1:13306. The app
+      # container talks to MySQL over the compose network on 3306.
+      - "13306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+      # Seed the database on first init. Files run alphabetically; numeric
+      # prefixes here control the apply order. Add new migrations to this list
+      # when you add a new file under pkg/db/migrations/.
+      - ./pkg/db/schema/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
+      - ./pkg/db/schema/car_part.sql:/docker-entrypoint-initdb.d/02-car_part.sql:ro
+      - ./pkg/db/migrations/0001_auth_tables.sql:/docker-entrypoint-initdb.d/10-0001-auth-tables.sql:ro
+      - ./pkg/db/migrations/0002_performance_indexes.sql:/docker-entrypoint-initdb.d/11-0002-performance-indexes.sql:ro
+      - ./pkg/db/migrations/0003_keyset_indexes.sql:/docker-entrypoint-initdb.d/12-0003-keyset-indexes.sql:ro
+      - ./pkg/db/migrations/0004_typed_filter_indexes.sql:/docker-entrypoint-initdb.d/13-0004-typed-filter-indexes.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-proot"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
+
+  nats:
+    # JetStream-enabled NATS for the ZATCA publisher (see pkg/handlers/pub.go).
+    image: nats:2.10-alpine
+    restart: unless-stopped
+    command: ["-js", "-sd", "/data"]
+    ports:
+      - "4222:4222"
+    volumes:
+      - nats-data:/data
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      # Override HOST so the app talks to the bundled MySQL service regardless
+      # of what .env says (handy when the same .env is reused on a server).
+      HOST: mysql:3306
+      NATS_URL: nats://nats:4222
+    ports:
+      # Host port 18090 to avoid clashing with another local service on 8090.
+      # Reach the API at http://localhost:18090/healthz.
+      - "18090:8090"
+    depends_on:
+      mysql:
+        condition: service_healthy
+      nats:
+        condition: service_started
+    healthcheck:
+      # Override the Dockerfile HEALTHCHECK (which uses --spider / HEAD) with a
+      # real GET, since Gin's /healthz route is registered for GET only.
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8090/healthz >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+
+volumes:
+  mysql-data:
+  nats-data:


### PR DESCRIPTION
Adds local-dev docker-compose for the backend (mysql + nats + app) and documents
the environment variables actually read by the code in `.env.example`.

## What this is
- `Dockerfile`: unchanged.
- `docker-compose.yml` (new): brings up `mysql:8`, `nats:2-alpine` (JetStream),
  and the app, wires healthchecks, and applies `pkg/db/migrations/*.sql` on
  first boot via the official MySQL `/docker-entrypoint-initdb.d/` hook.
- `.env.example` (new): documents `BASEURL`, `SERVER_PORT`, `HOST`, `DBUSER`,
  `PASSWORD`, `DBNAME`, `DB_TLS`, `DB_TIMEZONE`, `JWT_SECERT_KEY`,
  `VEHICLE_DATABASES{,_KEY}`, and `NATS_URL` — discovered by grepping
  `os.Getenv` across the dev branch.

## Why
There is no `.env.example` or compose file on `dev` today, so the only path to
"run locally" is to read `pkg/db/db.go` and `main.go` to discover the env
contract by hand. This adds a one-command local stack:

```bash
cp .env.example .env
docker compose up --build
curl http://localhost:8090/healthz   # → 200 OK
```

## Verified
- `docker compose up --build` brings all three containers to `healthy`.
- `/healthz` returns 200.
- Migrations apply cleanly on a fresh volume.

## Notes
- `JWT_SECERT_KEY` keeps the upstream typo so the example matches the env var
  the code actually reads.
- The compose healthcheck overrides the Dockerfile one because `wget --spider`
  issues HEAD and `/healthz` is GET-only.
- No code change. Production deploys (Dokku) are unaffected.