### PR TITLE
ci(backend): add deploy workflow to main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+# =============================================================================
+# Backend image build & push to Docker Hub
+# =============================================================================
+# Branch → tag mapping:
+#   dev  → :dev    (deploy server polls and pulls this)
+#   main → :latest
+#   any  → :<sha>  (immutable reference, used for rollbacks)
+#
+# Required GitHub Secrets:
+#   DOCKERHUB_USERNAME
+#   DOCKERHUB_TOKEN
+# =============================================================================
+
+name: Build & Push Backend
+
+on:
+  push:
+    branches: [main, dev]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/ifritah-api
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Re-open of #37 (stuck: mergeable_state=blocked despite all checks passing). The deploy workflow already exists on dev (publishes :dev). This adds the same workflow to main so:
- push to main -> publishes :latest and :<sha>
- push to dev  -> publishes :dev and :<sha> (unchanged)

Required existing repo secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.