### PR TITLE
fix(docker): include database schema in image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ RUN apk add --no-cache ca-certificates tzdata wget \
 WORKDIR /app
 
 COPY --from=builder /out/ifritah /app/ifritah
+COPY --chown=app:app pkg/db/schema /app/db/schema
+COPY --chown=app:app pkg/db/migrations /app/db/migrations
 
 RUN mkdir -p /app/uploads /app/data && chown -R app:app /app
 


### PR DESCRIPTION
## Summary
- copy backend-owned schema into `/app/db/schema`
- copy backend-owned migrations into `/app/db/migrations`
- keeps deployment from copying or owning schema files

## Notes
Deployment PR #50 reads schema/migrations from these image paths.

## Tests
- Docker build attempted locally, but the environment failed before this Dockerfile change due Alpine package mirror TLS (`apk` could not trust dl-cdn.alpinelinux.org).