### PR TITLE
Fix MySQL schema source and Docker build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,7 @@
 # =============================================================================
 
 # ---- Build stage ----
-FROM golang:1.25-alpine AS builder
-
-RUN apk add --no-cache git ca-certificates tzdata
+FROM golang:1.25-bookworm AS builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/pkg/db/migrations/0003_keyset_indexes.sql
+++ b/pkg/db/migrations/0003_keyset_indexes.sql
@@ -1,52 +1,22 @@
--- ============================================================================
--- 0003_keyset_indexes.sql
--- Composite indexes that support keyset pagination on the list endpoints.
---
--- Why these specific indexes:
---   The seek predicate is `WHERE (sort_value, id) < (?, ?)
---                          ORDER BY sort_value DESC, id DESC LIMIT N+1`.
---   For that to run as a single index range scan (no filesort, no temp
---   table) we need an index whose leading columns match the ORDER BY.
---   InnoDB silently appends the PK to every secondary index, so a key
---   on `(effective_date)` already sorts ties by `id` for free — but
---   declaring `(effective_date DESC, id DESC)` explicitly lets the
---   optimizer use the index in the natural scan direction, avoiding a
---   backward range scan that some older 8.0 minor versions still cost
---   higher than a filesort. (MySQL 8.0+ supports descending indexes;
---   we already pin to 8.0 in compose.)
---
--- The previously-shipped `(merchant_id, effective_date)` keys are kept
--- — they are still useful for any per-creator queries (dashboards,
--- audit). They do NOT serve the new list seek because `merchant_id`
--- (which actually stores the creator user id, not a tenant id) is not
--- in the WHERE clause of the new list queries.
---
--- Idempotent: `CREATE INDEX IF NOT EXISTS` (MySQL 8.0.29+) makes each
--- statement a no-op on a second run, so we no longer need the
--- per-index information_schema gate that 0002 used.
--- ============================================================================
+-- Keyset pagination indexes. MySQL 8.0 does not support the optional
+-- IF NOT EXISTS clause here, so each index is guarded like the other migrations.
 
-CREATE INDEX IF NOT EXISTS `idx_bill_keyset`
-    ON `bill` (`effective_date` DESC, `id` DESC);
+SET @s := IF((SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='bill' AND index_name='idx_bill_keyset')=0,
+    'CREATE INDEX `idx_bill_keyset` ON `bill` (`effective_date` DESC, `id` DESC)', 'DO 0');
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
 
-CREATE INDEX IF NOT EXISTS `idx_pb_keyset`
-    ON `purchase_bill` (`effective_date` DESC, `id` DESC);
+SET @s := IF((SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='purchase_bill' AND index_name='idx_pb_keyset')=0,
+    'CREATE INDEX `idx_pb_keyset` ON `purchase_bill` (`effective_date` DESC, `id` DESC)', 'DO 0');
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
 
-CREATE INDEX IF NOT EXISTS `idx_cv_keyset`
-    ON `cash_voucher` (`effective_date` DESC, `id` DESC);
+SET @s := IF((SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='cash_voucher' AND index_name='idx_cv_keyset')=0,
+    'CREATE INDEX `idx_cv_keyset` ON `cash_voucher` (`effective_date` DESC, `id` DESC)', 'DO 0');
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
 
--- Sorted by created_at DESC for the list page. Same DESC-DESC composite
--- so the seek is one index range read.
-CREATE INDEX IF NOT EXISTS `idx_orders_keyset`
-    ON `orders` (`created_at` DESC, `id` DESC);
+SET @s := IF((SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='orders' AND index_name='idx_orders_keyset')=0,
+    'CREATE INDEX `idx_orders_keyset` ON `orders` (`created_at` DESC, `id` DESC)', 'DO 0');
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;
 
--- Sorted by updated_at DESC, id DESC (matches existing GetClients ORDER BY
--- and surfaces recently-touched clients first, the existing UX contract).
-CREATE INDEX IF NOT EXISTS `idx_client_keyset`
-    ON `client` (`is_deleted`, `updated_at` DESC, `id` DESC);
-
--- supplier, product, branch, stores list pages all sort by `id DESC` only.
--- The InnoDB primary key already serves that scan order natively — no
--- additional index needed for the seek itself. The existing per-tenant
--- filter indexes (idx_supplier_company_active, idx_product_store_active_qty)
--- still match their respective handler filters.
+SET @s := IF((SELECT COUNT(*) FROM information_schema.statistics WHERE table_schema=DATABASE() AND table_name='client' AND index_name='idx_client_keyset')=0,
+    'CREATE INDEX `idx_client_keyset` ON `client` (`is_deleted`, `updated_at` DESC, `id` DESC)', 'DO 0');
+PREPARE st FROM @s; EXECUTE st; DEALLOCATE PREPARE st;

--- a/pkg/db/schema/schema.sql
+++ b/pkg/db/schema/schema.sql
@@ -887,23 +887,6 @@ CREATE TABLE `cash_voucher` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Temporary view structure for view `cash_voucher_summary`
---
-
-DROP TABLE IF EXISTS `cash_voucher_summary`;
-/*!50001 DROP VIEW IF EXISTS `cash_voucher_summary`*/;
-SET @saved_cs_client     = @@character_set_client;
-/*!50503 SET character_set_client = utf8mb4 */;
-/*!50001 CREATE VIEW `cash_voucher_summary` AS SELECT 
- 1 AS `voucher_type`,
- 1 AS `state`,
- 1 AS `merchant_id`,
- 1 AS `voucher_count`,
- 1 AS `total_amount`,
- 1 AS `month`*/;
-SET character_set_client = @saved_cs_client;
-
---
 -- Table structure for table `client`
 --
 
@@ -2326,22 +2309,24 @@ CREATE TABLE `zatca_submission` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Final view structure for view `cash_voucher_summary`
+-- View structure for view `cash_voucher_summary`
 --
 
-/*!50001 DROP VIEW IF EXISTS `cash_voucher_summary`*/;
-/*!50001 SET @saved_cs_client          = @@character_set_client */;
-/*!50001 SET @saved_cs_results         = @@character_set_results */;
-/*!50001 SET @saved_col_connection     = @@collation_connection */;
-/*!50001 SET character_set_client      = utf8mb4 */;
-/*!50001 SET character_set_results     = utf8mb4 */;
-/*!50001 SET collation_connection      = utf8mb4_0900_ai_ci */;
-/*!50001 CREATE ALGORITHM=UNDEFINED */
-/*!50013 DEFINER=`root`@`localhost` SQL SECURITY DEFINER */
-/*!50001 VIEW `cash_voucher_summary` AS select `cash_voucher`.`voucher_type` AS `voucher_type`,`cash_voucher`.`state` AS `state`,`cash_voucher`.`merchant_id` AS `merchant_id`,count(0) AS `voucher_count`,sum(`cash_voucher`.`amount`) AS `total_amount`,date_format(`cash_voucher`.`effective_date`,'%Y-%m') AS `month` from `cash_voucher` group by `cash_voucher`.`voucher_type`,`cash_voucher`.`state`,`cash_voucher`.`merchant_id`,date_format(`cash_voucher`.`effective_date`,'%Y-%m') */;
-/*!50001 SET character_set_client      = @saved_cs_client */;
-/*!50001 SET character_set_results     = @saved_cs_results */;
-/*!50001 SET collation_connection      = @saved_col_connection */;
+DROP VIEW IF EXISTS `cash_voucher_summary`;
+CREATE SQL SECURITY INVOKER VIEW `cash_voucher_summary` AS
+SELECT
+  `cash_voucher`.`voucher_type` AS `voucher_type`,
+  `cash_voucher`.`state` AS `state`,
+  `cash_voucher`.`merchant_id` AS `merchant_id`,
+  COUNT(0) AS `voucher_count`,
+  SUM(`cash_voucher`.`amount`) AS `total_amount`,
+  DATE_FORMAT(`cash_voucher`.`effective_date`, '%Y-%m') AS `month`
+FROM `cash_voucher`
+GROUP BY
+  `cash_voucher`.`voucher_type`,
+  `cash_voucher`.`state`,
+  `cash_voucher`.`merchant_id`,
+  DATE_FORMAT(`cash_voucher`.`effective_date`, '%Y-%m');
 
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 


### PR DESCRIPTION
I found an issue:
- Backend schema dump creates cash_voucher_summary with root@localhost SQL SECURITY DEFINER.
- Backend migration 0003 uses CREATE INDEX IF NOT EXISTS, which MySQL rejected in local tenant import.
- Backend Docker build stage used Alpine apk, which failed locally before Go build steps.

these are the fixes:
- Make cash_voucher_summary a clean SQL SECURITY INVOKER view in schema.sql.
- Rewrite 0003_keyset_indexes.sql to use the existing guarded information_schema pattern.
- Use a Debian Go builder stage and keep the Alpine runtime.

Tested:
- Source-built schema image imported locally through deployment with no SQL rewrite: 93 tables, 1 view, INVOKER.
- Schema import rerun passed.
- sqlc generate && go test ./... passed.
- Docker build smoke now reaches go mod download, but local Docker HTTPS trust fails with x509 unknown authority.