### PR TITLE
fix(db): maintain bill totals without triggers

### DIFF
--- a/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
+++ b/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
@@ -1,19 +1,3 @@
-DELIMITER //
-CREATE PROCEDURE drop_bill_total_triggers_0005()
-BEGIN
-  DECLARE CONTINUE HANDLER FOR 1360 BEGIN END;
-  DROP TRIGGER bill_product_after_insert_totals;
-  DROP TRIGGER bill_product_after_update_totals;
-  DROP TRIGGER bill_product_after_delete_totals;
-  DROP TRIGGER purchase_bill_product_after_insert_totals;
-  DROP TRIGGER purchase_bill_product_after_update_totals;
-  DROP TRIGGER purchase_bill_product_after_delete_totals;
-END//
-DELIMITER ;
-
-CALL drop_bill_total_triggers_0005();
-DROP PROCEDURE drop_bill_total_triggers_0005;
-
 UPDATE bill
 SET
   total_before_vat = COALESCE((SELECT SUM(total_before_vat) FROM bill_product WHERE bill_product.bill_id = bill.id), 0),


### PR DESCRIPTION
## Summary
- remove trigger/procedure creation from bill total runtime migration
- backfill bill and purchase bill totals with normal UPDATE statements
- refresh parent bill totals from application transactions after line item changes

## Security rationale
- avoids SUPER privileges
- avoids log_bin_trust_function_creators=1
- keeps tenant schema changes inside normal tenant DB DML privileges

## Validation
- sqlc generate
- go test ./...
- go build ./...