### PR TITLE
fix(db): maintain bill totals without triggers

### DIFF
--- a/pkg/db/queries/bill.sql
+++ b/pkg/db/queries/bill.sql
@@ -156,6 +156,15 @@ insert into bill_product (name, product_id, price, quantity, bill_id, part_name)
 -- name: DeleteProductToBill :exec
 DELETE FROM bill_product where bill_id = ?;
 
+-- name: RecalculateBillTotals :exec
+UPDATE bill
+SET
+  total_before_vat = COALESCE((SELECT SUM(bp.total_before_vat) FROM bill_product bp WHERE bp.bill_id = bill.id), 0),
+  total_vat = COALESCE((SELECT SUM(bp.vat_total) FROM bill_product bp WHERE bp.bill_id = bill.id), 0),
+  total = COALESCE((SELECT SUM(bp.total_including_vat) FROM bill_product bp WHERE bp.bill_id = bill.id), 0),
+  discount_amount = COALESCE((SELECT SUM(bp.discount) FROM bill_product bp WHERE bp.bill_id = bill.id), 0)
+WHERE bill.id = ?;
+
 -- name: GetBillProductByBillID :many
 select * from bill_product where bill_id = ?;
 

--- a/pkg/db/queries/purchase_bill.sql
+++ b/pkg/db/queries/purchase_bill.sql
@@ -42,6 +42,14 @@ UPDATE purchase_bill set effective_date = ?, payment_due_date = ?, state = ?, di
 -- name: DeleteProductPurchaseBill :exec
 DELETE FROM purchase_bill_product where bill_id = ?;
 
+-- name: RecalculatePurchaseBillTotals :exec
+UPDATE purchase_bill
+SET
+   total_before_vat = COALESCE((SELECT SUM(pbp.total_before_vat) FROM purchase_bill_product pbp WHERE pbp.bill_id = purchase_bill.id), 0),
+   total_vat = COALESCE((SELECT SUM(pbp.vat_total) FROM purchase_bill_product pbp WHERE pbp.bill_id = purchase_bill.id), 0),
+   total = COALESCE((SELECT SUM(pbp.total_including_vat) FROM purchase_bill_product pbp WHERE pbp.bill_id = purchase_bill.id), 0)
+WHERE purchase_bill.id = ?;
+
 -- name: AddPurchaseBill :execresult
 insert into purchase_bill (effective_date, payment_due_date, state, discount, store_id, merchant_id, supplier_id, supplier_sequence_number, pdf_link, payment_method, deliver_date)
 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
+++ b/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
@@ -1,19 +1,3 @@
-DELIMITER //
-CREATE PROCEDURE drop_bill_total_triggers_0005()
-BEGIN
-  DECLARE CONTINUE HANDLER FOR 1360 BEGIN END;
-  DROP TRIGGER bill_product_after_insert_totals;
-  DROP TRIGGER bill_product_after_update_totals;
-  DROP TRIGGER bill_product_after_delete_totals;
-  DROP TRIGGER purchase_bill_product_after_insert_totals;
-  DROP TRIGGER purchase_bill_product_after_update_totals;
-  DROP TRIGGER purchase_bill_product_after_delete_totals;
-END//
-DELIMITER ;
-
-CALL drop_bill_total_triggers_0005();
-DROP PROCEDURE drop_bill_total_triggers_0005;
-
 UPDATE bill
 SET
   total_before_vat = COALESCE((SELECT SUM(total_before_vat) FROM bill_product WHERE bill_product.bill_id = bill.id), 0),

--- a/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
+++ b/pkg/db/runtime_migrations/0005_bill_total_triggers.sql
@@ -1,3 +1,10 @@
+DROP TRIGGER IF EXISTS bill_product_after_insert_totals;
+DROP TRIGGER IF EXISTS bill_product_after_update_totals;
+DROP TRIGGER IF EXISTS bill_product_after_delete_totals;
+DROP TRIGGER IF EXISTS purchase_bill_product_after_insert_totals;
+DROP TRIGGER IF EXISTS purchase_bill_product_after_update_totals;
+DROP TRIGGER IF EXISTS purchase_bill_product_after_delete_totals;
+
 UPDATE bill
 SET
   total_before_vat = COALESCE((SELECT SUM(total_before_vat) FROM bill_product WHERE bill_product.bill_id = bill.id), 0),
@@ -10,80 +17,3 @@ SET
   total_before_vat = COALESCE((SELECT SUM(total_before_vat) FROM purchase_bill_product WHERE purchase_bill_product.bill_id = purchase_bill.id), 0),
   total_vat = COALESCE((SELECT SUM(vat_total) FROM purchase_bill_product WHERE purchase_bill_product.bill_id = purchase_bill.id), 0),
   total = COALESCE((SELECT SUM(total_including_vat) FROM purchase_bill_product WHERE purchase_bill_product.bill_id = purchase_bill.id), 0);
-
-CREATE TRIGGER bill_product_after_insert_totals
-AFTER INSERT ON bill_product
-FOR EACH ROW
-UPDATE bill
-SET
-  total_before_vat = total_before_vat + COALESCE(NEW.total_before_vat, 0),
-  total_vat = total_vat + COALESCE(NEW.vat_total, 0),
-  total = total + COALESCE(NEW.total_including_vat, 0),
-  discount_amount = discount_amount + COALESCE(NEW.discount, 0)
-WHERE id = NEW.bill_id;
-
-CREATE TRIGGER bill_product_after_update_totals
-AFTER UPDATE ON bill_product
-FOR EACH ROW
-UPDATE bill
-SET
-  total_before_vat = total_before_vat
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.total_before_vat, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.total_before_vat, 0) ELSE 0 END,
-  total_vat = total_vat
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.vat_total, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.vat_total, 0) ELSE 0 END,
-  total = total
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.total_including_vat, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.total_including_vat, 0) ELSE 0 END,
-  discount_amount = discount_amount
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.discount, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.discount, 0) ELSE 0 END
-WHERE id IN (OLD.bill_id, NEW.bill_id);
-
-CREATE TRIGGER bill_product_after_delete_totals
-AFTER DELETE ON bill_product
-FOR EACH ROW
-UPDATE bill
-SET
-  total_before_vat = total_before_vat - COALESCE(OLD.total_before_vat, 0),
-  total_vat = total_vat - COALESCE(OLD.vat_total, 0),
-  total = total - COALESCE(OLD.total_including_vat, 0),
-  discount_amount = discount_amount - COALESCE(OLD.discount, 0)
-WHERE id = OLD.bill_id;
-
-CREATE TRIGGER purchase_bill_product_after_insert_totals
-AFTER INSERT ON purchase_bill_product
-FOR EACH ROW
-UPDATE purchase_bill
-SET
-  total_before_vat = total_before_vat + COALESCE(NEW.total_before_vat, 0),
-  total_vat = total_vat + COALESCE(NEW.vat_total, 0),
-  total = total + COALESCE(NEW.total_including_vat, 0)
-WHERE id = NEW.bill_id;
-
-CREATE TRIGGER purchase_bill_product_after_update_totals
-AFTER UPDATE ON purchase_bill_product
-FOR EACH ROW
-UPDATE purchase_bill
-SET
-  total_before_vat = total_before_vat
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.total_before_vat, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.total_before_vat, 0) ELSE 0 END,
-  total_vat = total_vat
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.vat_total, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.vat_total, 0) ELSE 0 END,
-  total = total
-    - CASE WHEN id = OLD.bill_id THEN COALESCE(OLD.total_including_vat, 0) ELSE 0 END
-    + CASE WHEN id = NEW.bill_id THEN COALESCE(NEW.total_including_vat, 0) ELSE 0 END
-WHERE id IN (OLD.bill_id, NEW.bill_id);
-
-CREATE TRIGGER purchase_bill_product_after_delete_totals
-AFTER DELETE ON purchase_bill_product
-FOR EACH ROW
-UPDATE purchase_bill
-SET
-  total_before_vat = total_before_vat - COALESCE(OLD.total_before_vat, 0),
-  total_vat = total_vat - COALESCE(OLD.vat_total, 0),
-  total = total - COALESCE(OLD.total_including_vat, 0)
-WHERE id = OLD.bill_id;

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -255,6 +255,11 @@ func (h *handler) AddBill(c *gin.Context) {
 		c.AbortWithError(http.StatusBadRequest, err)
 		return
 	}
+	if err := qtx.RecalculateBillTotals(c.Request.Context(), uint64(id)); err != nil {
+		log.Printf("AddBill: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
 
 	// ── Stock tracking: deduct stock for catalog products ──
 	enforcement := h.getStockEnforcementMode(c)
@@ -388,6 +393,11 @@ func (h *handler) SubmitDraftBill(c *gin.Context) {
 
 	if err := addProductToBill(qtx, c, products, billID); err != nil {
 		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+	if err := qtx.RecalculateBillTotals(c.Request.Context(), billID); err != nil {
+		log.Printf("SubmitDraftBill: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 

--- a/pkg/handlers/purchase_bill.go
+++ b/pkg/handlers/purchase_bill.go
@@ -150,6 +150,11 @@ func (h *handler) UpdatePurchaseBill(c *gin.Context) {
 		c.Status(http.StatusBadRequest)
 		return
 	}
+	if err := qtx.RecalculatePurchaseBillTotals(c.Request.Context(), id); err != nil {
+		log.Printf("UpdatePurchaseBill: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
 
 	// ── Stock tracking: add new stock for updated products ──
 	if enforcement != model.StockEnforcementDisable && request.State > 0 {
@@ -234,6 +239,11 @@ func (h *handler) AddPurchaseBill(c *gin.Context) {
 	if err != nil {
 		log.Printf("AddPurchaseBill: %v", err)
 		c.Status(http.StatusBadRequest)
+		return
+	}
+	if err := qtx.RecalculatePurchaseBillTotals(c.Request.Context(), id); err != nil {
+		log.Printf("AddPurchaseBill: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- removes MySQL trigger creation from the bill total migration
- drops existing total-maintenance triggers if present and backfills cached totals with plain UPDATE statements
- recalculates bill and purchase bill totals inside the existing create/update transactions
- avoids SET_USER_ID, SUPER, and log_bin_trust_function_creators for this totals path

## Tests
- sqlc generate
- gofmt -w pkg/handlers/bill.go pkg/handlers/purchase_bill.go
- go test ./...
- git diff --check
- docker build -t ifritah-api:no-trigger-test .

Note: an extra Docker image content inspection was attempted after the successful build, but docker run hung while the local terminal was also reporting disk-space errors. Source grep and the built-image build step both passed.