### PR TITLE
Add WhatsApp invoice PDF sending

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/abdul-mohsen/go-arabic-pdf-lib v1.2.3
+	github.com/abdul-mohsen/go-whatsapp v0.0.0-20260518221046-6ad7504de147
 	github.com/gin-contrib/cache v1.4.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-playground/validator/v10 v10.30.1
@@ -58,3 +59,5 @@ require (
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/abdul-mohsen/go-whatsapp => github.com/abdulmohsenssda/go-whatsapp v0.0.0-20260518221046-6ad7504de147

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/abdul-mohsen/go-arabic-pdf-lib v1.2.3 h1:cYzcroF3r2L+whAnAcUhuRe16LYYZZ69QxnCS5XK2HY=
 github.com/abdul-mohsen/go-arabic-pdf-lib v1.2.3/go.mod h1:MNS6Yp6onFWaUqs9QIjzVy74HTQnyS/R9mTdqUT9NQQ=
+github.com/abdulmohsenssda/go-whatsapp v0.0.0-20260518221046-6ad7504de147 h1:CtjHOY6ThUYD89ZeYZ+TRr19KH/fhQP7fYQHV5SHBO8=
+github.com/abdulmohsenssda/go-whatsapp v0.0.0-20260518221046-6ad7504de147/go.mod h1:IFLHKvdtKfN40A6HHanS9XTfrrVDadLT8cmxenvoHhs=
 github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf h1:TqhNAT4zKbTdLa62d2HDBFdvgSbIGB3eJE8HqhgiL9I=
 github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=

--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 		authorized.GET("bill/:id", h.GetBillDetail)
 		authorized.POST("bill/all", h.GetBills)
 		authorized.POST("bill", h.AddBill)
+		authorized.POST("bill/:id/whatsapp", h.SendBillWhatsApp)
 		authorized.PUT("bill/:id", h.SubmitDraftBill)
 		authorized.DELETE("bill/:id", mgr, h.DeleteBillDetail)
 

--- a/pkg/db/migrations/0006_whatsapp_settings.sql
+++ b/pkg/db/migrations/0006_whatsapp_settings.sql
@@ -1,0 +1,10 @@
+-- 0006_whatsapp_settings.sql
+-- WhatsApp Business invoice PDF integration settings. Idempotent.
+
+INSERT IGNORE INTO settings (setting_key, value, description) VALUES
+  ('whatsapp_enabled',             'false', 'Enable WhatsApp Business invoice PDF sending'),
+  ('whatsapp_business_account_id', '',      'WhatsApp Business account ID'),
+  ('whatsapp_phone_number_id',     '',      'WhatsApp phone number ID'),
+  ('whatsapp_access_token',        '',      'WhatsApp Business API access token'),
+  ('whatsapp_api_version',         'v18.0', 'WhatsApp Graph API version'),
+  ('whatsapp_invoice_message',     'Invoice PDF is attached.', 'Default WhatsApp invoice PDF caption');

--- a/pkg/db/queries/settings.sql
+++ b/pkg/db/queries/settings.sql
@@ -1,0 +1,15 @@
+-- name: ListSettings :many
+SELECT setting_key, COALESCE(value, '') AS value
+FROM settings
+ORDER BY setting_key;
+
+-- name: GetSettingValue :one
+SELECT COALESCE(value, '') AS value
+FROM settings
+WHERE setting_key = ?
+LIMIT 1;
+
+-- name: UpsertSetting :exec
+INSERT INTO settings (setting_key, value, updated_by)
+VALUES (?, ?, ?)
+ON DUPLICATE KEY UPDATE value = VALUES(value), updated_by = VALUES(updated_by);

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -489,19 +489,23 @@ func getNextSquenceNumber(qtx *db.Queries, c *gin.Context) uint64 {
 	return uint64(maxSequenceNumber) + 1
 }
 
-func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProductResponse) {
-
-	Id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-
-	if err != nil {
-		c.AbortWithError(http.StatusBadRequest, err)
-		return model.Bill{}, nil
+func parsePositiveBillID(rawID string) (uint64, error) {
+	billID, err := strconv.ParseUint(rawID, 10, 64)
+	if err != nil || billID == 0 {
+		return 0, fmt.Errorf("invalid bill id")
 	}
+	return billID, nil
+}
 
-	id := uint64(Id)
-
-	bill, err := h.queries.GetBillPDFByID(c.Request.Context(), id)
-	dbProducts, err := h.queries.GetBillProductByBillID(c.Request.Context(), bill.ID)
+func (h *handler) getBillDetailByID(ctx context.Context, id uint64) (model.Bill, []model.BillProductResponse, error) {
+	bill, err := h.queries.GetBillPDFByID(ctx, id)
+	if err != nil {
+		return model.Bill{}, nil, err
+	}
+	dbProducts, err := h.queries.GetBillProductByBillID(ctx, bill.ID)
+	if err != nil {
+		return model.Bill{}, nil, err
+	}
 	var xProducts []model.BillProductResponse
 	for _, product := range dbProducts {
 		name := "ERR"
@@ -510,7 +514,7 @@ func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProduct
 		} else if product.ProductID != nil {
 			name = fmt.Sprint(product.ProductID)
 		} else {
-			return model.Bill{}, nil
+			return model.Bill{}, nil, fmt.Errorf("bill product has no name or product id")
 		}
 
 		u := ""
@@ -568,8 +572,12 @@ func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProduct
 	var client *db.Client = nil
 
 	if bill.ClientID != nil {
-		Client, _ := h.queries.GetClientByID(c.Request.Context(), uint32(*bill.ClientID))
-		client = &Client
+		Client, err := h.queries.GetClientByID(ctx, uint32(*bill.ClientID))
+		if err != nil {
+			log.Printf("getBillDetailByID: %v", err)
+		} else {
+			client = &Client
+		}
 	}
 	return model.Bill{
 		Id:                           bill.ID,
@@ -608,7 +616,26 @@ func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProduct
 		PaymentMethod: bill.PaymentMethod,
 		DeliverDate:   bill.DeliverDate,
 		BranchID:      bill.BranchID,
-	}, xProducts
+	}, xProducts, nil
+
+}
+
+func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProductResponse) {
+	billID, err := parsePositiveBillID(c.Param("id"))
+	if err != nil {
+		log.Printf("getBillDetail: %v", err)
+		c.AbortWithError(http.StatusBadRequest, err)
+		return model.Bill{}, nil
+	}
+
+	bill, products, err := h.getBillDetailByID(c.Request.Context(), billID)
+	if err != nil {
+		log.Printf("getBillDetail: %v", err)
+		c.AbortWithError(http.StatusBadRequest, err)
+		return model.Bill{}, nil
+	}
+
+	return bill, products
 }
 
 func (h *handler) GetBillDetail(c *gin.Context) {
@@ -624,9 +651,9 @@ func (h *handler) GetBillPDF(c *gin.Context) {
 	// Path-traversal hardening (Sonar gosecurity:S2083): the param feeds
 	// filepath.Join below, so any value containing path separators or
 	// `..` segments could escape the downloads directory.
-	rawID := c.Param("id")
-	billID, err := strconv.ParseUint(rawID, 10, 64)
-	if err != nil || billID == 0 {
+	billID, err := parsePositiveBillID(c.Param("id"))
+	if err != nil {
+		log.Printf("GetBillPDF: %v", err)
 		c.Status(http.StatusBadRequest)
 		return
 	}
@@ -634,27 +661,10 @@ func (h *handler) GetBillPDF(c *gin.Context) {
 
 	filename := filepath.Join("/var", "www", "html", "downloads", id+".pdf")
 	if true {
-		bill, products := h.getBillDetail(c)
-		for _, p := range products {
-			if p.Name == model.MaintenanceCost {
-				p.Name = "تكلفة الصيانة"
-			}
-		}
-
-		var invoice invoice.Invoice
-		if bill.Client == nil {
-			invoice = b2cInvoice(true, models.PaperThermal, bill, products).
-				WithType(models.InvoiceTypeB2C).
-				Build()
-		} else {
-			invoice = b2bInvoice(true, models.PaperA4, bill, products, *bill.Client).
-				WithType(models.InvoiceTypeB2B).
-				Build()
-		}
-
-		fontDir := "fonts"
-		pdfBytes, err := pdf.GenerateInvoiceBytes(invoice, fontDir)
+		pdfBytes, _, err := h.buildBillPDFBytes(c.Request.Context(), billID)
 		if err != nil {
+			log.Printf("GetBillPDF: %v", err)
+			c.Status(http.StatusInternalServerError)
 			return
 		}
 
@@ -668,6 +678,42 @@ func (h *handler) GetBillPDF(c *gin.Context) {
 
 	c.File(filename)
 
+}
+
+func (h *handler) buildBillPDFBytes(ctx context.Context, billID uint64) ([]byte, model.Bill, error) {
+	bill, products, err := h.getBillDetailByID(ctx, billID)
+	if err != nil {
+		return nil, model.Bill{}, err
+	}
+
+	pdfBytes, err := generateBillPDFBytes(bill, products)
+	if err != nil {
+		return nil, model.Bill{}, err
+	}
+
+	return pdfBytes, bill, nil
+}
+
+func generateBillPDFBytes(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
+	return pdf.GenerateInvoiceBytes(buildBillInvoice(bill, products), "fonts")
+}
+
+func buildBillInvoice(bill model.Bill, products []model.BillProductResponse) invoice.Invoice {
+	for i := range products {
+		if products[i].Name == model.MaintenanceCost {
+			products[i].Name = "تكلفة الصيانة"
+		}
+	}
+
+	if bill.Client == nil {
+		return b2cInvoice(true, models.PaperThermal, bill, products).
+			WithType(models.InvoiceTypeB2C).
+			Build()
+	}
+
+	return b2bInvoice(true, models.PaperA4, bill, products, *bill.Client).
+		WithType(models.InvoiceTypeB2B).
+		Build()
 }
 
 func (h *handler) GetBillCreditDetail(c *gin.Context) {

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -686,13 +686,15 @@ func (h *handler) buildBillPDFBytes(ctx context.Context, billID uint64) ([]byte,
 		return nil, model.Bill{}, err
 	}
 
-	pdfBytes, err := generateBillPDFBytes(bill, products)
+	pdfBytes, err := renderBillPDFBytes(bill, products)
 	if err != nil {
 		return nil, model.Bill{}, err
 	}
 
 	return pdfBytes, bill, nil
 }
+
+var renderBillPDFBytes = generateBillPDFBytes
 
 func generateBillPDFBytes(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
 	return pdf.GenerateInvoiceBytes(buildBillInvoice(bill, products), "fonts")

--- a/pkg/handlers/bill.go
+++ b/pkg/handlers/bill.go
@@ -489,9 +489,9 @@ func getNextSquenceNumber(qtx *db.Queries, c *gin.Context) uint64 {
 	return uint64(maxSequenceNumber) + 1
 }
 
-func parsePositiveBillID(rawID string) (uint64, error) {
+func parseBillID(rawID string) (uint64, error) {
 	billID, err := strconv.ParseUint(rawID, 10, 64)
-	if err != nil || billID == 0 {
+	if err != nil {
 		return 0, fmt.Errorf("invalid bill id")
 	}
 	return billID, nil
@@ -621,7 +621,7 @@ func (h *handler) getBillDetailByID(ctx context.Context, id uint64) (model.Bill,
 }
 
 func (h *handler) getBillDetail(c *gin.Context) (model.Bill, []model.BillProductResponse) {
-	billID, err := parsePositiveBillID(c.Param("id"))
+	billID, err := parseBillID(c.Param("id"))
 	if err != nil {
 		log.Printf("getBillDetail: %v", err)
 		c.AbortWithError(http.StatusBadRequest, err)
@@ -651,7 +651,7 @@ func (h *handler) GetBillPDF(c *gin.Context) {
 	// Path-traversal hardening (Sonar gosecurity:S2083): the param feeds
 	// filepath.Join below, so any value containing path separators or
 	// `..` segments could escape the downloads directory.
-	billID, err := parsePositiveBillID(c.Param("id"))
+	billID, err := parseBillID(c.Param("id"))
 	if err != nil {
 		log.Printf("GetBillPDF: %v", err)
 		c.Status(http.StatusBadRequest)
@@ -686,15 +686,13 @@ func (h *handler) buildBillPDFBytes(ctx context.Context, billID uint64) ([]byte,
 		return nil, model.Bill{}, err
 	}
 
-	pdfBytes, err := renderBillPDFBytes(bill, products)
+	pdfBytes, err := h.renderBillPDFBytes(bill, products)
 	if err != nil {
 		return nil, model.Bill{}, err
 	}
 
 	return pdfBytes, bill, nil
 }
-
-var renderBillPDFBytes = generateBillPDFBytes
 
 func generateBillPDFBytes(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
 	return pdf.GenerateInvoiceBytes(buildBillInvoice(bill, products), "fonts")

--- a/pkg/handlers/error_messages.go
+++ b/pkg/handlers/error_messages.go
@@ -8,10 +8,15 @@ package handlers
 // with the frontend.
 const (
 	// 400 Bad Request
-	ErrInvalidRequest    = "invalid request"
-	ErrInvalidUserID     = "invalid user id"
-	ErrInvalidRole       = "invalid role"
-	ErrNoFieldsToUpdate  = "no fields to update"
+	ErrInvalidRequest   = "invalid request"
+	ErrInvalidUserID    = "invalid user id"
+	ErrInvalidRole      = "invalid role"
+	ErrNoFieldsToUpdate = "no fields to update"
+	ErrInvalidInvoiceID = "invalid invoice id"
+	ErrWhatsAppDisabled = "whatsapp integration is disabled"
+	ErrWhatsAppConfig   = "whatsapp credentials are incomplete"
+	ErrWhatsAppNoPhone  = "customer phone number is missing"
+	ErrWhatsAppBadPhone = "customer phone number is invalid"
 
 	// 401 Unauthorized
 	ErrInvalidCredentials = "invalid credentials"
@@ -24,7 +29,8 @@ const (
 	ErrAccountDeactivated = "account is deactivated"
 
 	// 404 Not Found
-	ErrUserNotFound = "user not found"
+	ErrUserNotFound    = "user not found"
+	ErrInvoiceNotFound = "invoice not found"
 
 	// 409 Conflict
 	ErrUsernameExists = "username already exists"
@@ -42,6 +48,8 @@ const (
 	ErrUpdatePassword      = "failed to update password"
 	ErrGenerateAccessTok   = "could not generate access token"
 	ErrGenerateRefreshTok  = "could not generate refresh token"
+	ErrGenerateInvoicePDF  = "failed to generate invoice pdf"
+	ErrSendWhatsAppMessage = "failed to send whatsapp message"
 )
 
 // invalidRequestDetail returns the canonical "invalid request" string with

--- a/pkg/handlers/handler.go
+++ b/pkg/handlers/handler.go
@@ -11,10 +11,13 @@ import (
 )
 
 type handler struct {
-	DB      *sql.DB
-	queries *db.Queries
-	pub     *ZatcaPublisher
+	DB            *sql.DB
+	queries       *db.Queries
+	pub           *ZatcaPublisher
+	renderBillPDF billPDFRenderer
 }
+
+type billPDFRenderer func(model.Bill, []model.BillProductResponse) ([]byte, error)
 
 type userSession struct {
 	id       int64
@@ -23,7 +26,20 @@ type userSession struct {
 }
 
 func New(db *sql.DB, queries *db.Queries, pub *ZatcaPublisher) handler {
-	return handler{db, queries, pub}
+	return handler{
+		DB:            db,
+		queries:       queries,
+		pub:           pub,
+		renderBillPDF: generateBillPDFBytes,
+	}
+}
+
+func (h *handler) renderBillPDFBytes(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
+	renderer := h.renderBillPDF
+	if renderer == nil {
+		renderer = generateBillPDFBytes
+	}
+	return renderer(bill, products)
 }
 
 func EnvSetup() {

--- a/pkg/handlers/setting.go
+++ b/pkg/handlers/setting.go
@@ -15,7 +15,7 @@ package handlers
 //       value TEXT, description VARCHAR(255),
 //       updated_by INT, updated_at DATETIME
 //
-// Settings are organized into 7 categories (42 keys total):
+// Settings are organized into 8 categories:
 //   1. company (9)    — company_name, company_vat, company_cr, etc.
 //   2. invoice (12)   — currency, vat_rate, invoice_prefix, etc.
 //   3. print (7)      — paper_size, print_copies, show_logo_print, etc.
@@ -23,16 +23,24 @@ package handlers
 //   5. notifications (5) — notif_invoices, notif_stock, etc.
 //   6. security (4)   — session_duration, max_login_attempts, etc.
 //   7. inventory (6)  — low_stock_threshold, default_unit, etc.
+//   8. integrations (6) — WhatsApp Business settings
 //
 // ZATCA config is NOT in settings — it's per-branch in branch_zatca_config.
 // Stock enforcement (stock_enforcement key) is read separately by stock handlers.
 // ============================================================================
 
 import (
+	"database/sql"
+	db "ifritah/web-service-gin/pkg/db/gen"
+	"ifritah/web-service-gin/pkg/model"
+	"log"
 	"net/http"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
+
+const maskedWhatsAppAccessToken = "********"
 
 // settingCategories maps each setting_key to its category name.
 // Used by both GetSettings (to group) and UpdateSettings (to whitelist).
@@ -100,6 +108,29 @@ var settingCategories = map[string]string{
 
 	// ── Stock enforcement (read by stock handlers, editable via inventory) ──
 	"stock_enforcement": "inventory",
+
+	// ── Section 8: Integrations (6 keys) ──
+	"whatsapp_enabled":             "integrations",
+	"whatsapp_business_account_id": "integrations",
+	"whatsapp_phone_number_id":     "integrations",
+	"whatsapp_access_token":        "integrations",
+	"whatsapp_api_version":         "integrations",
+	"whatsapp_invoice_message":     "integrations",
+}
+
+func maskSettingValue(key, value string) string {
+	if key == "whatsapp_access_token" && strings.TrimSpace(value) != "" {
+		return maskedWhatsAppAccessToken
+	}
+	return value
+}
+
+func shouldPreserveSettingValue(key, value string) bool {
+	if key != "whatsapp_access_token" {
+		return false
+	}
+	trimmed := strings.TrimSpace(value)
+	return trimmed == "" || trimmed == maskedWhatsAppAccessToken
 }
 
 // ── GET /api/v2/settings ────────────────────────────────────────────────────
@@ -120,12 +151,12 @@ var settingCategories = map[string]string{
 //	}
 
 func (h *handler) GetSettings(c *gin.Context) {
-	rows, err := h.DB.Query("SELECT setting_key, COALESCE(value,'') FROM settings ORDER BY setting_key")
+	settings, err := h.queries.ListSettings(c.Request.Context())
 	if err != nil {
+		log.Printf("GetSettings: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"detail": "failed to fetch settings"})
 		return
 	}
-	defer rows.Close()
 
 	// Initialize all category maps
 	grouped := map[string]map[string]string{
@@ -136,15 +167,12 @@ func (h *handler) GetSettings(c *gin.Context) {
 		"notifications": {},
 		"security":      {},
 		"inventory":     {},
+		"integrations":  {},
 	}
 
-	for rows.Next() {
-		var key, value string
-		if err := rows.Scan(&key, &value); err != nil {
-			continue
-		}
-		if cat, ok := settingCategories[key]; ok {
-			grouped[cat][key] = value
+	for _, setting := range settings {
+		if cat, ok := settingCategories[setting.SettingKey]; ok {
+			grouped[cat][setting.SettingKey] = maskSettingValue(setting.SettingKey, setting.Value)
 		}
 	}
 
@@ -161,16 +189,14 @@ func (h *handler) GetSettings(c *gin.Context) {
 //	  "settings": {"company_name": "عفريته", "company_vat": "123456789012345"}
 //	}
 //
-// Valid categories: company, invoice, print, appearance, notifications, security, inventory
+// Valid categories: company, invoice, print, appearance, notifications, security, inventory, integrations
 //
 // Response: {"detail": "success"}
 
 func (h *handler) UpdateSettings(c *gin.Context) {
-	var req struct {
-		Category string            `json:"category" binding:"required"`
-		Settings map[string]string `json:"settings" binding:"required"`
-	}
+	var req model.UpdateSettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
+		log.Printf("UpdateSettings: %v", err)
 		c.JSON(http.StatusBadRequest, gin.H{"detail": "invalid request"})
 		return
 	}
@@ -179,13 +205,14 @@ func (h *handler) UpdateSettings(c *gin.Context) {
 	validCategories := map[string]bool{
 		"company": true, "invoice": true, "print": true,
 		"appearance": true, "notifications": true, "security": true, "inventory": true,
+		"integrations": true,
 	}
 	if !validCategories[req.Category] {
 		c.JSON(http.StatusBadRequest, gin.H{"detail": "invalid category"})
 		return
 	}
 
-	userID := GetSessionInfo(c).id
+	userID := int32(GetSessionInfo(c).id)
 
 	updated := 0
 	for key, value := range req.Settings {
@@ -195,15 +222,28 @@ func (h *handler) UpdateSettings(c *gin.Context) {
 			continue
 		}
 
-		_, err := h.DB.Exec(
-			`INSERT INTO settings (setting_key, value, updated_by)
-			 VALUES (?, ?, ?)
-			 ON DUPLICATE KEY UPDATE value = VALUES(value), updated_by = VALUES(updated_by)`,
-			key, value, userID,
-		)
-		if err == nil {
-			updated++
+		if shouldPreserveSettingValue(key, value) {
+			existingValue, err := h.queries.GetSettingValue(c.Request.Context(), key)
+			if err != nil && err != sql.ErrNoRows {
+				log.Printf("UpdateSettings: %v", err)
+				continue
+			}
+			if strings.TrimSpace(existingValue) == "" {
+				continue
+			}
+			value = existingValue
 		}
+
+		err := h.queries.UpsertSetting(c.Request.Context(), db.UpsertSettingParams{
+			SettingKey: key,
+			Value:      &value,
+			UpdatedBy:  &userID,
+		})
+		if err != nil {
+			log.Printf("UpdateSettings: %v", err)
+			continue
+		}
+		updated++
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/pkg/handlers/whatsapp.go
+++ b/pkg/handlers/whatsapp.go
@@ -82,14 +82,14 @@ func (h *handler) SendBillWhatsApp(c *gin.Context) {
 		return
 	}
 
-	pdfBytes, bill, err := h.buildBillPDFBytes(c.Request.Context(), billID)
+	bill, products, err := h.getBillDetailByID(c.Request.Context(), billID)
 	if err != nil {
 		log.Printf("SendBillWhatsApp: %v", err)
 		if errors.Is(err, sql.ErrNoRows) {
 			c.JSON(http.StatusNotFound, model.WhatsAppSendResponse{Detail: ErrInvoiceNotFound})
 			return
 		}
-		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrGenerateInvoicePDF})
+		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrDatabase})
 		return
 	}
 
@@ -101,6 +101,13 @@ func (h *handler) SendBillWhatsApp(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppBadPhone})
+		return
+	}
+
+	pdfBytes, err := renderBillPDFBytes(bill, products)
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrGenerateInvoicePDF})
 		return
 	}
 

--- a/pkg/handlers/whatsapp.go
+++ b/pkg/handlers/whatsapp.go
@@ -1,0 +1,258 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"ifritah/web-service-gin/pkg/model"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	waclient "github.com/abdul-mohsen/go-whatsapp/pkg/client"
+	waconfig "github.com/abdul-mohsen/go-whatsapp/pkg/config"
+	wamodels "github.com/abdul-mohsen/go-whatsapp/pkg/models"
+)
+
+const (
+	whatsappEnabledKey           = "whatsapp_enabled"
+	whatsappBusinessAccountIDKey = "whatsapp_business_account_id"
+	whatsappPhoneNumberIDKey     = "whatsapp_phone_number_id"
+	whatsappAccessTokenKey       = "whatsapp_access_token"
+	whatsappAPIVersionKey        = "whatsapp_api_version"
+	whatsappInvoiceMessageKey    = "whatsapp_invoice_message"
+
+	defaultWhatsAppAPIVersion     = "v18.0"
+	defaultWhatsAppInvoiceMessage = "Invoice PDF is attached."
+)
+
+type whatsappSettings struct {
+	Enabled           bool
+	BusinessAccountID string
+	PhoneNumberID     string
+	AccessToken       string
+	APIVersion        string
+	InvoiceMessage    string
+}
+
+type whatsappClient interface {
+	UploadMediaBytes(ctx context.Context, data []byte, filename, mimeType string) (*wamodels.MediaUploadResponse, error)
+	SendDocument(ctx context.Context, to string, doc *wamodels.DocumentContent) (*wamodels.MessageResponse, error)
+}
+
+var newWhatsAppClient = func(settings whatsappSettings) (whatsappClient, error) {
+	cfg := waconfig.DefaultConfig()
+	cfg.BusinessAccountID = settings.BusinessAccountID
+	cfg.PhoneNumberID = settings.PhoneNumberID
+	cfg.AccessToken = settings.AccessToken
+	cfg.APIVersion = settings.APIVersion
+	return waclient.New(cfg)
+}
+
+func defaultWhatsAppSettings() whatsappSettings {
+	return whatsappSettings{
+		APIVersion:     defaultWhatsAppAPIVersion,
+		InvoiceMessage: defaultWhatsAppInvoiceMessage,
+	}
+}
+
+func (h *handler) SendBillWhatsApp(c *gin.Context) {
+	billID, err := parsePositiveBillID(c.Param("id"))
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrInvalidInvoiceID})
+		return
+	}
+
+	settings, err := h.loadWhatsAppSettings(c.Request.Context())
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrDatabase})
+		return
+	}
+	if !settings.Enabled {
+		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppDisabled})
+		return
+	}
+	if !settings.hasCredentials() {
+		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppConfig})
+		return
+	}
+
+	pdfBytes, bill, err := h.buildBillPDFBytes(c.Request.Context(), billID)
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		if errors.Is(err, sql.ErrNoRows) {
+			c.JSON(http.StatusNotFound, model.WhatsAppSendResponse{Detail: ErrInvoiceNotFound})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrGenerateInvoicePDF})
+		return
+	}
+
+	recipient, err := normalizeWhatsAppPhone(selectBillWhatsAppPhone(bill))
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		if errors.Is(err, errMissingWhatsAppPhone) {
+			c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppNoPhone})
+			return
+		}
+		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppBadPhone})
+		return
+	}
+
+	waClient, err := newWhatsAppClient(settings)
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrWhatsAppConfig})
+		return
+	}
+
+	filename := fmt.Sprintf("invoice-%d.pdf", bill.Id)
+	mediaResp, err := waClient.UploadMediaBytes(c.Request.Context(), pdfBytes, filename, "application/pdf")
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusBadGateway, model.WhatsAppSendResponse{Detail: ErrSendWhatsAppMessage})
+		return
+	}
+
+	messageResp, err := waClient.SendDocument(c.Request.Context(), recipient, &wamodels.DocumentContent{
+		ID:       mediaResp.ID,
+		Caption:  formatWhatsAppInvoiceMessage(settings.InvoiceMessage, bill),
+		Filename: filename,
+	})
+	if err != nil {
+		log.Printf("SendBillWhatsApp: %v", err)
+		c.JSON(http.StatusBadGateway, model.WhatsAppSendResponse{Detail: ErrSendWhatsAppMessage})
+		return
+	}
+
+	c.JSON(http.StatusOK, model.WhatsAppSendResponse{
+		Detail:    "sent",
+		MessageID: firstWhatsAppMessageID(messageResp),
+	})
+}
+
+func (h *handler) loadWhatsAppSettings(ctx context.Context) (whatsappSettings, error) {
+	settings := defaultWhatsAppSettings()
+	rows, err := h.queries.ListSettings(ctx)
+	if err != nil {
+		return settings, err
+	}
+
+	for _, row := range rows {
+		value := strings.TrimSpace(row.Value)
+		switch row.SettingKey {
+		case whatsappEnabledKey:
+			settings.Enabled = strings.EqualFold(value, "true") || value == "1"
+		case whatsappBusinessAccountIDKey:
+			settings.BusinessAccountID = value
+		case whatsappPhoneNumberIDKey:
+			settings.PhoneNumberID = value
+		case whatsappAccessTokenKey:
+			settings.AccessToken = value
+		case whatsappAPIVersionKey:
+			if value != "" {
+				settings.APIVersion = value
+			}
+		case whatsappInvoiceMessageKey:
+			if value != "" {
+				settings.InvoiceMessage = value
+			}
+		}
+	}
+
+	return settings, nil
+}
+
+func (s whatsappSettings) hasCredentials() bool {
+	return strings.TrimSpace(s.BusinessAccountID) != "" &&
+		strings.TrimSpace(s.PhoneNumberID) != "" &&
+		strings.TrimSpace(s.AccessToken) != "" &&
+		strings.TrimSpace(s.APIVersion) != ""
+}
+
+func selectBillWhatsAppPhone(bill model.Bill) string {
+	if bill.Client != nil && bill.Client.Phone != nil && strings.TrimSpace(*bill.Client.Phone) != "" {
+		return *bill.Client.Phone
+	}
+	if bill.UserPhoneNumber != nil {
+		return *bill.UserPhoneNumber
+	}
+	return ""
+}
+
+var (
+	errMissingWhatsAppPhone = errors.New("missing whatsapp phone")
+	errInvalidWhatsAppPhone = errors.New("invalid whatsapp phone")
+)
+
+func normalizeWhatsAppPhone(phone string) (string, error) {
+	phone = strings.TrimSpace(phone)
+	if phone == "" {
+		return "", errMissingWhatsAppPhone
+	}
+
+	var digits strings.Builder
+	for i, r := range phone {
+		switch {
+		case r >= '0' && r <= '9':
+			digits.WriteRune(r)
+		case i == 0 && r == '+':
+			continue
+		case r == ' ' || r == '-' || r == '(' || r == ')':
+			continue
+		default:
+			return "", errInvalidWhatsAppPhone
+		}
+	}
+
+	normalized := digits.String()
+	if strings.HasPrefix(normalized, "05") {
+		normalized = "966" + normalized[1:]
+	} else if strings.HasPrefix(normalized, "5") {
+		normalized = "966" + normalized
+	}
+	if len(normalized) < 8 {
+		return "", errInvalidWhatsAppPhone
+	}
+	return normalized, nil
+}
+
+func formatWhatsAppInvoiceMessage(template string, bill model.Bill) string {
+	if strings.TrimSpace(template) == "" {
+		template = defaultWhatsAppInvoiceMessage
+	}
+
+	sequenceNumber := ""
+	if bill.SequenceNumber != nil {
+		sequenceNumber = fmt.Sprint(*bill.SequenceNumber)
+	}
+
+	customerName := ""
+	if bill.Client != nil {
+		customerName = bill.Client.Name
+		if bill.Client.CompanyName != nil && strings.TrimSpace(*bill.Client.CompanyName) != "" {
+			customerName = *bill.Client.CompanyName
+		}
+	} else if bill.UserName != nil {
+		customerName = *bill.UserName
+	}
+
+	return strings.NewReplacer(
+		"{invoice_id}", fmt.Sprint(bill.Id),
+		"{sequence_number}", sequenceNumber,
+		"{customer_name}", customerName,
+		"{total}", bill.Total,
+	).Replace(template)
+}
+
+func firstWhatsAppMessageID(resp *wamodels.MessageResponse) string {
+	if resp == nil || len(resp.Messages) == 0 {
+		return ""
+	}
+	return resp.Messages[0].ID
+}

--- a/pkg/handlers/whatsapp.go
+++ b/pkg/handlers/whatsapp.go
@@ -60,7 +60,7 @@ func defaultWhatsAppSettings() whatsappSettings {
 }
 
 func (h *handler) SendBillWhatsApp(c *gin.Context) {
-	billID, err := parsePositiveBillID(c.Param("id"))
+	billID, err := parseBillID(c.Param("id"))
 	if err != nil {
 		log.Printf("SendBillWhatsApp: %v", err)
 		c.JSON(http.StatusBadRequest, model.WhatsAppSendResponse{Detail: ErrInvalidInvoiceID})
@@ -104,7 +104,7 @@ func (h *handler) SendBillWhatsApp(c *gin.Context) {
 		return
 	}
 
-	pdfBytes, err := renderBillPDFBytes(bill, products)
+	pdfBytes, err := h.renderBillPDFBytes(bill, products)
 	if err != nil {
 		log.Printf("SendBillWhatsApp: %v", err)
 		c.JSON(http.StatusInternalServerError, model.WhatsAppSendResponse{Detail: ErrGenerateInvoicePDF})

--- a/pkg/handlers/whatsapp_test.go
+++ b/pkg/handlers/whatsapp_test.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	db "ifritah/web-service-gin/pkg/db/gen"
+	"ifritah/web-service-gin/pkg/model"
+	"testing"
+)
+
+func TestNormalizeWhatsAppPhone(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "international with separators", input: "+966 55-123-4567", want: "966551234567"},
+		{name: "local leading zero", input: "0551234567", want: "966551234567"},
+		{name: "local without zero", input: "551234567", want: "966551234567"},
+		{name: "invalid characters", input: "05abc", wantErr: true},
+		{name: "too short", input: "123", wantErr: true},
+		{name: "missing", input: " ", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := normalizeWhatsAppPhone(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectBillWhatsAppPhonePrefersClientPhone(t *testing.T) {
+	clientPhone := "0551111111"
+	walkInPhone := "0552222222"
+	bill := model.Bill{
+		Client:          &db.Client{Phone: &clientPhone},
+		UserPhoneNumber: &walkInPhone,
+	}
+
+	if got := selectBillWhatsAppPhone(bill); got != clientPhone {
+		t.Fatalf("got %q, want client phone %q", got, clientPhone)
+	}
+}
+
+func TestSelectBillWhatsAppPhoneFallsBackToWalkInPhone(t *testing.T) {
+	walkInPhone := "0552222222"
+	bill := model.Bill{
+		Client:          &db.Client{},
+		UserPhoneNumber: &walkInPhone,
+	}
+
+	if got := selectBillWhatsAppPhone(bill); got != walkInPhone {
+		t.Fatalf("got %q, want walk-in phone %q", got, walkInPhone)
+	}
+}
+
+func TestFormatWhatsAppInvoiceMessage(t *testing.T) {
+	sequenceNumber := uint64(42)
+	companyName := "ACME Parts"
+	bill := model.Bill{
+		Id:             99,
+		SequenceNumber: &sequenceNumber,
+		Total:          "123.45",
+		Client: &db.Client{
+			Name:        "Client Name",
+			CompanyName: &companyName,
+		},
+	}
+
+	got := formatWhatsAppInvoiceMessage("Invoice {invoice_id}/{sequence_number} for {customer_name}: {total}", bill)
+	want := "Invoice 99/42 for ACME Parts: 123.45"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestSettingTokenMaskAndPreserve(t *testing.T) {
+	if got := maskSettingValue("whatsapp_access_token", "secret-token"); got != maskedWhatsAppAccessToken {
+		t.Fatalf("got %q, want masked token", got)
+	}
+	if got := maskSettingValue("whatsapp_access_token", " "); got != " " {
+		t.Fatalf("blank token should stay blank, got %q", got)
+	}
+	if !shouldPreserveSettingValue("whatsapp_access_token", "") {
+		t.Fatalf("blank token should preserve existing value")
+	}
+	if !shouldPreserveSettingValue("whatsapp_access_token", maskedWhatsAppAccessToken) {
+		t.Fatalf("masked token should preserve existing value")
+	}
+	if shouldPreserveSettingValue("whatsapp_access_token", "new-token") {
+		t.Fatalf("new token should be updated")
+	}
+}

--- a/pkg/handlers/whatsapp_test.go
+++ b/pkg/handlers/whatsapp_test.go
@@ -1,10 +1,410 @@
 package handlers
 
 import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
 	db "ifritah/web-service-gin/pkg/db/gen"
 	"ifritah/web-service-gin/pkg/model"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	wamodels "github.com/abdul-mohsen/go-whatsapp/pkg/models"
+	"github.com/gin-gonic/gin"
 )
+
+var (
+	listSettingsPattern  = regexp.QuoteMeta("SELECT setting_key, COALESCE(value, '') AS value\nFROM settings\nORDER BY setting_key")
+	getSettingPattern    = regexp.QuoteMeta("SELECT COALESCE(value, '') AS value\nFROM settings\nWHERE setting_key = ?\nLIMIT 1")
+	upsertSettingPattern = regexp.QuoteMeta("INSERT INTO settings (setting_key, value, updated_by)\n" +
+		"VALUES (?, ?, ?)\n" +
+		"ON DUPLICATE KEY UPDATE value = VALUES(value), updated_by = VALUES(updated_by)")
+	getBillPDFPattern      = regexp.QuoteMeta("SELECT b.id, b.effective_date, b.payment_due_date, b.state, b.discount, b.store_id, b.sequence_number, b.merchant_id, b.maintenance_cost, b.note, b.username, b.client_id, b.user_phone_number, b.qr_code, b.invoice_uuid, b.invoice_hash, b.branch_id, b.payment_method, b.deliver_date, b.invoice_xml_path, b.total_before_vat, b.total_vat, b.total, b.discount_amount, b.amount_paid, b.sequence_number_str,")
+	getBillProductsPattern = regexp.QuoteMeta("select id, product_id, bill_id, vat, price, quantity, name, part_name, type, discount, total_before_discount, total_before_vat, vat_total, total_including_vat from bill_product where bill_id = ?")
+)
+
+type responseDetail struct {
+	Detail    string `json:"detail"`
+	MessageID string `json:"message_id"`
+}
+
+type fakeWhatsAppClient struct {
+	uploadData     []byte
+	uploadFilename string
+	uploadMimeType string
+	sendTo         string
+	sendDocument   *wamodels.DocumentContent
+}
+
+func (f *fakeWhatsAppClient) UploadMediaBytes(_ context.Context, data []byte, filename, mimeType string) (*wamodels.MediaUploadResponse, error) {
+	f.uploadData = data
+	f.uploadFilename = filename
+	f.uploadMimeType = mimeType
+	return &wamodels.MediaUploadResponse{ID: "media-123"}, nil
+}
+
+func (f *fakeWhatsAppClient) SendDocument(_ context.Context, to string, doc *wamodels.DocumentContent) (*wamodels.MessageResponse, error) {
+	f.sendTo = to
+	f.sendDocument = doc
+	return &wamodels.MessageResponse{Messages: []wamodels.MessageInfo{{ID: "wamid.123"}}}, nil
+}
+
+func newMockHandler(t *testing.T) (*handler, sqlmock.Sqlmock, func()) {
+	t.Helper()
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	h := New(sqlDB, db.New(sqlDB), nil)
+	return &h, mock, func() { _ = sqlDB.Close() }
+}
+
+func runHandlerRequest(t *testing.T, handlerFunc gin.HandlerFunc, method, path, body string, params gin.Params, withSession bool) *httptest.ResponseRecorder {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(method, path, strings.NewReader(body))
+	c.Request.Header.Set("Content-Type", "application/json")
+	c.Params = params
+	if withSession {
+		c.Set("decoded_jwt", &model.Claims{Id: 7, Username: "admin"})
+	}
+	handlerFunc(c)
+	return w
+}
+
+func decodeDetail(t *testing.T, w *httptest.ResponseRecorder) responseDetail {
+	t.Helper()
+	var response responseDetail
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v body=%s", err, w.Body.String())
+	}
+	return response
+}
+
+func expectListSettings(mock sqlmock.Sqlmock, values map[string]string) {
+	rows := sqlmock.NewRows([]string{"setting_key", "value"})
+	for _, key := range []string{
+		whatsappEnabledKey,
+		whatsappBusinessAccountIDKey,
+		whatsappPhoneNumberIDKey,
+		whatsappAccessTokenKey,
+		whatsappAPIVersionKey,
+		whatsappInvoiceMessageKey,
+	} {
+		if value, ok := values[key]; ok {
+			rows.AddRow(key, value)
+		}
+	}
+	mock.ExpectQuery(listSettingsPattern).WillReturnRows(rows)
+}
+
+func enabledWhatsAppSettings(message string) map[string]string {
+	return map[string]string{
+		whatsappEnabledKey:           "true",
+		whatsappBusinessAccountIDKey: "business-1",
+		whatsappPhoneNumberIDKey:     "phone-1",
+		whatsappAccessTokenKey:       "token-1",
+		whatsappAPIVersionKey:        "v18.0",
+		whatsappInvoiceMessageKey:    message,
+	}
+}
+
+func expectUpsertSetting(mock sqlmock.Sqlmock, key, value string) {
+	mock.ExpectExec(upsertSettingPattern).
+		WithArgs(key, value, sqlmock.AnyArg()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func expectBillDetail(mock sqlmock.Sqlmock, id uint64, userPhone *string, userName *string, sequence uint64, total string) {
+	columns := []string{
+		"id", "effective_date", "payment_due_date", "state", "discount", "store_id", "sequence_number",
+		"merchant_id", "maintenance_cost", "note", "username", "client_id", "user_phone_number", "qr_code",
+		"invoice_uuid", "invoice_hash", "branch_id", "payment_method", "deliver_date", "invoice_xml_path",
+		"total_before_vat", "total_vat", "total", "discount_amount", "amount_paid", "sequence_number_str",
+		"company_name", "vat_registration_number", "commercial_registration_number", "address_name", "store_name",
+		"credit_state", "credit_note", "credit_id",
+	}
+	sequenceString := "42"
+	rows := sqlmock.NewRows(columns).AddRow(
+		id,
+		time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC),
+		nil,
+		int32(1),
+		"0.00",
+		int32(1),
+		sequence,
+		int32(7),
+		"0.00",
+		nil,
+		userName,
+		nil,
+		userPhone,
+		nil,
+		sql.NullString{},
+		nil,
+		nil,
+		int32(0),
+		nil,
+		nil,
+		"100.00",
+		"23.45",
+		total,
+		"0.00",
+		"0.00",
+		&sequenceString,
+		"Ifritah",
+		nil,
+		nil,
+		nil,
+		"Main Store",
+		nil,
+		nil,
+		nil,
+	)
+	mock.ExpectQuery(getBillPDFPattern).WithArgs(id).WillReturnRows(rows)
+	mock.ExpectQuery(getBillProductsPattern).WithArgs(id).WillReturnRows(sqlmock.NewRows([]string{
+		"id", "product_id", "bill_id", "vat", "price", "quantity", "name", "part_name", "type", "discount",
+		"total_before_discount", "total_before_vat", "vat_total", "total_including_vat",
+	}))
+}
+
+func assertExpectations(t *testing.T, mock sqlmock.Sqlmock) {
+	t.Helper()
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet sql expectations: %v", err)
+	}
+}
+
+func TestGetSettingsIncludesIntegrationsAndMasksToken(t *testing.T) {
+	h, mock, cleanup := newMockHandler(t)
+	defer cleanup()
+	expectListSettings(mock, map[string]string{
+		whatsappEnabledKey:           "false",
+		whatsappBusinessAccountIDKey: "business-1",
+		whatsappPhoneNumberIDKey:     "phone-1",
+		whatsappAccessTokenKey:       "secret-token",
+		whatsappAPIVersionKey:        "v18.0",
+		whatsappInvoiceMessageKey:    "Invoice PDF is attached.",
+	})
+
+	w := runHandlerRequest(t, h.GetSettings, http.MethodGet, "/settings", "", nil, false)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	var response struct {
+		Data map[string]map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if _, ok := response.Data["integrations"]; !ok {
+		t.Fatalf("expected integrations category, got %#v", response.Data)
+	}
+	if got := response.Data["integrations"][whatsappAccessTokenKey]; got != maskedWhatsAppAccessToken {
+		t.Fatalf("token got %q, want masked", got)
+	}
+	assertExpectations(t, mock)
+}
+
+func TestUpdateSettingsTokenPreserveAndReplace(t *testing.T) {
+	tests := []struct {
+		name           string
+		body           string
+		expectGetToken bool
+		expectToken    string
+	}{
+		{
+			name:        "omitted token leaves it untouched",
+			body:        `{"category":"integrations","settings":{"whatsapp_api_version":"v19.0"}}`,
+			expectToken: "",
+		},
+		{
+			name:           "blank token preserves old token",
+			body:           `{"category":"integrations","settings":{"whatsapp_access_token":""}}`,
+			expectGetToken: true,
+			expectToken:    "old-token",
+		},
+		{
+			name:           "masked token preserves old token",
+			body:           `{"category":"integrations","settings":{"whatsapp_access_token":"********"}}`,
+			expectGetToken: true,
+			expectToken:    "old-token",
+		},
+		{
+			name:        "new token replaces old token",
+			body:        `{"category":"integrations","settings":{"whatsapp_access_token":"new-token"}}`,
+			expectToken: "new-token",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h, mock, cleanup := newMockHandler(t)
+			defer cleanup()
+			if tt.expectGetToken {
+				mock.ExpectQuery(getSettingPattern).
+					WithArgs(whatsappAccessTokenKey).
+					WillReturnRows(sqlmock.NewRows([]string{"value"}).AddRow("old-token"))
+			}
+			if strings.Contains(tt.body, whatsappAPIVersionKey) {
+				expectUpsertSetting(mock, whatsappAPIVersionKey, "v19.0")
+			} else {
+				expectUpsertSetting(mock, whatsappAccessTokenKey, tt.expectToken)
+			}
+
+			w := runHandlerRequest(t, h.UpdateSettings, http.MethodPut, "/settings", tt.body, nil, true)
+			if w.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+			}
+			assertExpectations(t, mock)
+		})
+	}
+}
+
+func TestSendBillWhatsAppValidationBehavior(t *testing.T) {
+	t.Run("invalid invoice id", func(t *testing.T) {
+		h, mock, cleanup := newMockHandler(t)
+		defer cleanup()
+		w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/nope/whatsapp", "", gin.Params{{Key: "id", Value: "nope"}}, false)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		if got := decodeDetail(t, w).Detail; got != ErrInvalidInvoiceID {
+			t.Fatalf("detail=%q", got)
+		}
+		assertExpectations(t, mock)
+	})
+
+	t.Run("disabled integration", func(t *testing.T) {
+		h, mock, cleanup := newMockHandler(t)
+		defer cleanup()
+		expectListSettings(mock, map[string]string{whatsappEnabledKey: "false"})
+		w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/10/whatsapp", "", gin.Params{{Key: "id", Value: "10"}}, false)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		if got := decodeDetail(t, w).Detail; got != ErrWhatsAppDisabled {
+			t.Fatalf("detail=%q", got)
+		}
+		assertExpectations(t, mock)
+	})
+
+	t.Run("missing credentials", func(t *testing.T) {
+		h, mock, cleanup := newMockHandler(t)
+		defer cleanup()
+		expectListSettings(mock, map[string]string{whatsappEnabledKey: "true"})
+		w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/10/whatsapp", "", gin.Params{{Key: "id", Value: "10"}}, false)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		if got := decodeDetail(t, w).Detail; got != ErrWhatsAppConfig {
+			t.Fatalf("detail=%q", got)
+		}
+		assertExpectations(t, mock)
+	})
+
+	t.Run("missing phone", func(t *testing.T) {
+		h, mock, cleanup := newMockHandler(t)
+		defer cleanup()
+		expectListSettings(mock, enabledWhatsAppSettings(defaultWhatsAppInvoiceMessage))
+		expectBillDetail(mock, 10, nil, nil, 42, "123.45")
+		w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/10/whatsapp", "", gin.Params{{Key: "id", Value: "10"}}, false)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		if got := decodeDetail(t, w).Detail; got != ErrWhatsAppNoPhone {
+			t.Fatalf("detail=%q", got)
+		}
+		assertExpectations(t, mock)
+	})
+
+	t.Run("invalid phone", func(t *testing.T) {
+		h, mock, cleanup := newMockHandler(t)
+		defer cleanup()
+		phone := "05abc"
+		name := "Walk In"
+		expectListSettings(mock, enabledWhatsAppSettings(defaultWhatsAppInvoiceMessage))
+		expectBillDetail(mock, 10, &phone, &name, 42, "123.45")
+		w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/10/whatsapp", "", gin.Params{{Key: "id", Value: "10"}}, false)
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+		}
+		if got := decodeDetail(t, w).Detail; got != ErrWhatsAppBadPhone {
+			t.Fatalf("detail=%q", got)
+		}
+		assertExpectations(t, mock)
+	})
+}
+
+func TestSendBillWhatsAppHappyPathBehavior(t *testing.T) {
+	h, mock, cleanup := newMockHandler(t)
+	defer cleanup()
+
+	oldRender := renderBillPDFBytes
+	oldClientFactory := newWhatsAppClient
+	defer func() {
+		renderBillPDFBytes = oldRender
+		newWhatsAppClient = oldClientFactory
+	}()
+
+	pdfBytes := []byte("%PDF fake invoice")
+	renderBillPDFBytes = func(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
+		if bill.Id != 10 {
+			t.Fatalf("render bill id=%d", bill.Id)
+		}
+		return pdfBytes, nil
+	}
+
+	fakeClient := &fakeWhatsAppClient{}
+	newWhatsAppClient = func(settings whatsappSettings) (whatsappClient, error) {
+		if settings.AccessToken != "token-1" {
+			t.Fatalf("unexpected token %q", settings.AccessToken)
+		}
+		return fakeClient, nil
+	}
+
+	phone := "0551234567"
+	name := "Walk In Customer"
+	expectListSettings(mock, enabledWhatsAppSettings("Invoice {invoice_id}/{sequence_number} for {customer_name}: {total}"))
+	expectBillDetail(mock, 10, &phone, &name, 42, "123.45")
+
+	w := runHandlerRequest(t, h.SendBillWhatsApp, http.MethodPost, "/bill/10/whatsapp", "", gin.Params{{Key: "id", Value: "10"}}, false)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	response := decodeDetail(t, w)
+	if response.Detail != "sent" || response.MessageID != "wamid.123" {
+		t.Fatalf("response=%#v", response)
+	}
+	if !bytes.Equal(fakeClient.uploadData, pdfBytes) {
+		t.Fatalf("uploaded pdf bytes mismatch")
+	}
+	if fakeClient.uploadMimeType != "application/pdf" {
+		t.Fatalf("mime=%q", fakeClient.uploadMimeType)
+	}
+	if fakeClient.uploadFilename != "invoice-10.pdf" {
+		t.Fatalf("filename=%q", fakeClient.uploadFilename)
+	}
+	if fakeClient.sendTo != "966551234567" {
+		t.Fatalf("sendTo=%q", fakeClient.sendTo)
+	}
+	if fakeClient.sendDocument == nil || fakeClient.sendDocument.ID != "media-123" {
+		t.Fatalf("send document=%#v", fakeClient.sendDocument)
+	}
+	if got := fakeClient.sendDocument.Caption; got != "Invoice 10/42 for Walk In Customer: 123.45" {
+		t.Fatalf("caption=%q", got)
+	}
+	assertExpectations(t, mock)
+}
 
 func TestNormalizeWhatsAppPhone(t *testing.T) {
 	tests := []struct {

--- a/pkg/handlers/whatsapp_test.go
+++ b/pkg/handlers/whatsapp_test.go
@@ -349,15 +349,13 @@ func TestSendBillWhatsAppHappyPathBehavior(t *testing.T) {
 	h, mock, cleanup := newMockHandler(t)
 	defer cleanup()
 
-	oldRender := renderBillPDFBytes
 	oldClientFactory := newWhatsAppClient
 	defer func() {
-		renderBillPDFBytes = oldRender
 		newWhatsAppClient = oldClientFactory
 	}()
 
 	pdfBytes := []byte("%PDF fake invoice")
-	renderBillPDFBytes = func(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
+	h.renderBillPDF = func(bill model.Bill, products []model.BillProductResponse) ([]byte, error) {
 		if bill.Id != 10 {
 			t.Fatalf("render bill id=%d", bill.Id)
 		}

--- a/pkg/model/settings.go
+++ b/pkg/model/settings.go
@@ -1,0 +1,11 @@
+package model
+
+type UpdateSettingsRequest struct {
+	Category string            `json:"category" binding:"required"`
+	Settings map[string]string `json:"settings" binding:"required"`
+}
+
+type WhatsAppSendResponse struct {
+	Detail    string `json:"detail"`
+	MessageID string `json:"message_id,omitempty"`
+}


### PR DESCRIPTION
Thread: whatsapp-pdf-integration

Implements sending existing invoice PDFs to customers through WhatsApp Business.

Backend contract:
- `POST /api/v2/bill/:id/whatsapp`
- success: `{ "detail": "sent", "message_id": "optional-wa-id" }`
- errors: `{ "detail": "safe error message" }`

Settings:
- adds `integrations` settings category
- masks `whatsapp_access_token` on GET
- preserves existing token when PUT omits it, sends blank, or sends `********`

Important dependency note:
- This branch temporarily uses a fork `replace` for `github.com/abdul-mohsen/go-whatsapp` because upstream PR #2 is not merged yet.
- Depends on https://github.com/abdul-mohsen/go-whatsapp/pull/2
- Before final merge, remove the temporary replace after PR #2 is merged and consume upstream cleanly.

Validation:
- `sqlc generate`
- `go test ./...`
- `go build ./...`
- VS Code test runner: 42 passed