### PR TITLE
feat: add supplier search API endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -53,6 +53,7 @@ func main() {
 
 		// ── Suppliers (employees can read/create, manager+ can edit/delete) ──
 		authorized.POST("supplier/all", h.GetAllSupplier)
+		authorized.GET("supplier/search", h.SearchSuppliers)
 		authorized.GET("supplier/:id", h.GetSupplier)
 		authorized.POST("supplier", h.AddSupplier)
 		authorized.PUT("supplier/:id", mgr, h.EditSupplier)

--- a/pkg/db/queries/supplier.sql
+++ b/pkg/db/queries/supplier.sql
@@ -18,5 +18,15 @@ WHERE is_deleted = FALSE
 ORDER BY id DESC
 LIMIT ?;
 
+-- name: SearchSuppliers :many
+SELECT id, name, number as code FROM supplier
+WHERE is_deleted = FALSE
+  AND company_id = ?
+  AND (sqlc.narg('query_like') IS NULL
+       OR name LIKE sqlc.narg('query_like')
+       OR number LIKE sqlc.narg('query_like'))
+ORDER BY name ASC
+LIMIT ?;
+
 -- name: AddSupplier :execresult
 INSERT INTO supplier (company_id, name, address, phone_number, number, vat_number, bank_account, is_postpaid, credit_limit, payment_terms_days, preferred_payment_method, commercial_registration, short_address, email) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/pkg/handlers/list_helpers_test.go
+++ b/pkg/handlers/list_helpers_test.go
@@ -97,3 +97,40 @@ func TestBuildBillSearchParams_Empty(t *testing.T) {
 		t.Fatalf("empty query must yield nil/nil, got name=%v phone=%v", name, phone)
 	}
 }
+
+// TestSupplierSequenceNumberLiveFilterContract verifies that incremental
+// prefix filtering on supplier_sequence_number works for live typing UX.
+// Frontend sends partial sequences (1, 12, 123, etc) and expects matching bills.
+func TestSupplierSequenceNumberLiveFilterContract(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    *string
+		expected *string
+	}{
+		{"nil input no filter", nil, nil},
+		{"empty string no filter", strPtr(""), nil},
+		{"whitespace no filter", strPtr("   "), nil},
+		{"single digit", strPtr("1"), strPtr("1%")},
+		{"two digits", strPtr("12"), strPtr("12%")},
+		{"three digits", strPtr("123"), strPtr("123%")},
+		{"four digits", strPtr("1234"), strPtr("1234%")},
+		{"trimmed prefix", strPtr("  45  "), strPtr("45%")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := buildPlainPrefixFilter(tc.input)
+			if tc.expected == nil {
+				if prefix != nil {
+					t.Fatalf("expected nil prefix, got %v", prefix)
+				}
+				return
+			}
+			if prefix == nil {
+				t.Fatalf("expected prefix %q, got nil", *tc.expected)
+			}
+			if *prefix != *tc.expected {
+				t.Fatalf("expected %q, got %q", *tc.expected, *prefix)
+			}
+		})
+	}
+}

--- a/pkg/handlers/supplier.go
+++ b/pkg/handlers/supplier.go
@@ -243,3 +243,49 @@ func (h *handler) DeleteSupplier(c *gin.Context) {
 
 	c.Status(http.StatusNoContent)
 }
+
+func (h *handler) SearchSuppliers(c *gin.Context) {
+	userSession := GetSessionInfo(c)
+
+	companyID, err := h.queries.GetCompanyIdByUser(c.Request.Context(), int32(userSession.id))
+	if err != nil || companyID == nil {
+		log.Printf("SearchSuppliers: %v", err)
+		c.AbortWithError(http.StatusBadRequest, err)
+		return
+	}
+
+	q := c.Query("q")
+	queryLike, _ := buildLikeAndDigitsExact(&q)
+
+	const maxResults = 100
+	suppliers, err := h.queries.SearchSuppliers(c.Request.Context(), db.SearchSuppliersParams{
+		CompanyID: *companyID,
+		QueryLike: queryLike,
+		Limit:     maxResults,
+	})
+	if err != nil {
+		log.Printf("SearchSuppliers: %v", err)
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
+	// Map to response model
+	results := make([]model.SearchSupplierResponse, len(suppliers))
+	for i, s := range suppliers {
+		name := ""
+		code := ""
+		if s.Name != nil {
+			name = *s.Name
+		}
+		if s.Code != nil {
+			code = *s.Code
+		}
+		results[i] = model.SearchSupplierResponse{
+			ID:   s.ID,
+			Name: name,
+			Code: code,
+		}
+	}
+
+	c.IndentedJSON(http.StatusOK, results)
+}

--- a/pkg/handlers/supplier_search_test.go
+++ b/pkg/handlers/supplier_search_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	db "ifritah/web-service-gin/pkg/db/gen"
+	"ifritah/web-service-gin/pkg/model"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/gin-gonic/gin"
+)
+
+func newSupplierTestHandler(t *testing.T) (*handler, sqlmock.Sqlmock, func()) {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	h := New(sqlDB, db.New(sqlDB), nil)
+	return &h, mock, func() { _ = sqlDB.Close() }
+}
+
+func runSupplierSearchRequest(t *testing.T, handlerFunc gin.HandlerFunc, query string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("GET", "/supplier/search?q="+query, nil)
+	c.Set("decoded_jwt", &model.Claims{Id: 7, Username: "testuser"})
+
+	handlerFunc(c)
+	return w
+}
+
+func TestSearchSuppliers(t *testing.T) {
+	testCases := []struct {
+		name      string
+		query     string
+		rows      [][]interface{}
+		wantCount int
+		wantError bool
+	}{
+		{
+			name:  "empty query returns all",
+			query: "",
+			rows: [][]interface{}{
+				{int64(1), "Electronics Supplier", "ELEC-001"},
+				{int64(2), "Parts Co", "PARTS-001"},
+			},
+			wantCount: 2,
+		},
+		{
+			name:  "substring match electronics",
+			query: "elec",
+			rows: [][]interface{}{
+				{int64(1), "Electronics Supplier", "ELEC-001"},
+			},
+			wantCount: 1,
+		},
+		{
+			name:  "code substring match",
+			query: "PARTS",
+			rows: [][]interface{}{
+				{int64(2), "Parts Co", "PARTS-001"},
+			},
+			wantCount: 1,
+		},
+		{
+			name:      "no matches",
+			query:     "nonexistent",
+			rows:      [][]interface{}{},
+			wantCount: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h, mock, cleanup := newSupplierTestHandler(t)
+			defer cleanup()
+
+			// Mock GetCompanyIdByUser (just match the SELECT part)
+			companyID := int32(100)
+			mock.ExpectQuery("SELECT company_id FROM user where id = \\?").
+				WithArgs(int32(7)).
+				WillReturnRows(sqlmock.NewRows([]string{"company_id"}).AddRow(companyID))
+
+			// Mock SearchSuppliers (match SQL pattern without comment)
+			rowsBuilder := sqlmock.NewRows([]string{"id", "name", "code"})
+			for _, row := range tc.rows {
+				rowsBuilder.AddRow(row[0], row[1], row[2])
+			}
+			mock.ExpectQuery("SELECT id, name, number as code FROM supplier").
+				WithArgs(companyID, sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), int32(100)).
+				WillReturnRows(rowsBuilder)
+
+			w := runSupplierSearchRequest(t, h.SearchSuppliers, tc.query)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body=%s", w.Code, http.StatusOK, w.Body.String())
+			}
+
+			var results []model.SearchSupplierResponse
+			if err := json.Unmarshal(w.Body.Bytes(), &results); err != nil {
+				t.Fatalf("unmarshal response: %v", err)
+			}
+
+			if len(results) != tc.wantCount {
+				t.Fatalf("got %d results, want %d; results=%+v", len(results), tc.wantCount, results)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet SQL expectations: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/model/supplier.go
+++ b/pkg/model/supplier.go
@@ -1,0 +1,7 @@
+package model
+
+type SearchSupplierResponse struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Code string `json:"code"`
+}


### PR DESCRIPTION
Adds GET /api/v2/supplier/search?q=query endpoint for supplier dropdown search. Filters suppliers by name or code substring (case-insensitive). Returns [id, name, code]. Tenant scoped to company_id. Includes regression tests.